### PR TITLE
[FEAT] 닉네임중복확인 API 구현 (#50)

### DIFF
--- a/src/main/java/com/partnerd/repository/memberRepository/MemberRepository.java
+++ b/src/main/java/com/partnerd/repository/memberRepository/MemberRepository.java
@@ -13,4 +13,12 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
      * @return Optional<Member>
      */
     Optional<Member> findBySocialId(String socialId);
+
+    /**
+     * 닉네임 중복 여부 확인
+     *
+     * @param nickname 중복 확인할 닉네임
+     * @return 중복 여부
+     */
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/partnerd/service/memberService/MemberService.java
+++ b/src/main/java/com/partnerd/service/memberService/MemberService.java
@@ -9,4 +9,7 @@ public interface MemberService {
 
     // 내프로필 수정
     Member updateMember(MemberRequestDTO.UpdateMemberDTO request, Long memberId);
+
+    // 닉네임 중복 확인
+    boolean isNicknameDuplicate(String nickname);
 }

--- a/src/main/java/com/partnerd/service/memberService/MemberServiceImpl.java
+++ b/src/main/java/com/partnerd/service/memberService/MemberServiceImpl.java
@@ -47,4 +47,10 @@ public class MemberServiceImpl implements MemberService {
 
         return memberRepository.save(existingMember);
     }
+
+    // 닉네임 중복 확인
+    @Override
+    public boolean isNicknameDuplicate(String nickname) {
+        return memberRepository.existsByNickname(nickname);
+    }
 }

--- a/src/main/java/com/partnerd/web/controller/MemberRestController.java
+++ b/src/main/java/com/partnerd/web/controller/MemberRestController.java
@@ -52,4 +52,19 @@ public class MemberRestController {
         Member member = memberService.updateMember(request, memberId);
         return ApiResponse.onSuccess(MemberConverter.toUpdateMemberResultDTO(member));
     }
+
+    @GetMapping("/users/nickname/check")
+    @Operation(summary = "닉네임 중복 확인 API", description = "닉네임 중복 여부를 확인하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.")
+    })
+    @Parameters({
+            @Parameter(name = "nickname", description = "중복 확인할 닉네임, query parameter 입니다!")
+    })
+    public ApiResponse<Boolean> checkNickname(@RequestParam String nickname) {
+        boolean isDuplicate = memberService.isNicknameDuplicate(nickname);
+        return ApiResponse.onSuccess(isDuplicate);
+    }
+
 }


### PR DESCRIPTION
# PR 템플릿

## #️⃣ 연관된 이슈

> Closes #50

## 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 📝 작업 내용

> - MemberRestController에 닉네임 중복 확인 엔드포인트 추가
> - MemberService 인터페이스 및 구현체에 중복 확인 로직 추가
> - MemberRepository에 existsByNickname 메서드 추가

## 💬 피드백을 받고 싶은 부분 (선택)

### PR 특이 사항
