### PR TITLE
[FEAT] 파트너드 찾기 전체 목록 조회 API구현(페이징)

### DIFF
--- a/src/main/java/com/partnerd/converter/ClubConverter.java
+++ b/src/main/java/com/partnerd/converter/ClubConverter.java
@@ -2,10 +2,7 @@ package com.partnerd.converter;
 
 import com.partnerd.domain.Category;
 import com.partnerd.domain.Club;
-import com.partnerd.web.dto.clubDTO.ClubRegisterRequestDTO;
-import com.partnerd.web.dto.clubDTO.ClubRegisterResponseDTO;
-import com.partnerd.web.dto.clubDTO.ClubUpdateRequestDTO;
-import com.partnerd.web.dto.clubDTO.ClubUpdateResponseDTO;
+import com.partnerd.web.dto.clubDTO.*;
 
 import java.util.ArrayList;
 
@@ -45,5 +42,13 @@ public class ClubConverter {
     public static ClubUpdateResponseDTO toClubUpdateResponseDTO(Club club) {
         return new ClubUpdateResponseDTO(club.getId(), club.getName(), club.getCategory().getId(),
                 club.getCategory().getName());
+    }
+
+    public static ClubDTO toClubDTO(Club club){
+        return new ClubDTO(
+                club.getProfile(),
+                club.getName(),
+                club.getIntro()
+        );
     }
 }

--- a/src/main/java/com/partnerd/domain/Club.java
+++ b/src/main/java/com/partnerd/domain/Club.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Club {
+public class Club extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/partnerd/repository/clubRepository/ClubRepository.java
+++ b/src/main/java/com/partnerd/repository/clubRepository/ClubRepository.java
@@ -1,10 +1,24 @@
 package com.partnerd.repository.clubRepository;
 
 import com.partnerd.domain.Club;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface ClubRepository extends JpaRepository<Club, Long> {
     List<Club> findTop4ClubByOrderByViewsDesc();
+
+    // 전체 인기순 정렬
+    Page<Club> findAllByOrderByViewsDesc(Pageable pageable);
+
+    // 전체 최신순 정렬
+    Page<Club> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    // 특정 카테고리 인기순 정렬
+    Page<Club> findByCategoryIdOrderByViewsDesc(Long categoryId, Pageable pageable);
+
+    // 특정 카테고리 최신순 정렬
+    Page<Club> findByCategoryIdOrderByCreatedAtDesc(Long categoryId, Pageable pageable);
 }

--- a/src/main/java/com/partnerd/service/clubService/ClubService.java
+++ b/src/main/java/com/partnerd/service/clubService/ClubService.java
@@ -1,13 +1,14 @@
 package com.partnerd.service.clubService;
 
-import com.partnerd.web.dto.clubDTO.ClubRegisterRequestDTO;
-import com.partnerd.web.dto.clubDTO.ClubRegisterResponseDTO;
-import com.partnerd.web.dto.clubDTO.ClubUpdateRequestDTO;
-import com.partnerd.web.dto.clubDTO.ClubUpdateResponseDTO;
+import com.partnerd.web.dto.clubDTO.*;
+
+import java.util.List;
 
 public interface ClubService {
     ClubRegisterResponseDTO registerClub(ClubRegisterRequestDTO dto);
     void deleteClub(Long clubId);
 
     ClubUpdateResponseDTO updateClub(Long clubId, ClubUpdateRequestDTO dto);
+
+    List<ClubDTO> getClubs(Integer page, String sort, Long categoryId);
 }

--- a/src/main/java/com/partnerd/service/clubService/impl/ClubServiceImpl.java
+++ b/src/main/java/com/partnerd/service/clubService/impl/ClubServiceImpl.java
@@ -10,11 +10,12 @@ import com.partnerd.domain.ContactMethod;
 import com.partnerd.repository.categoryRepository.CategoryRepository;
 import com.partnerd.repository.clubRepository.ClubRepository;
 import com.partnerd.service.clubService.ClubService;
-import com.partnerd.web.dto.clubDTO.ClubRegisterRequestDTO;
-import com.partnerd.web.dto.clubDTO.ClubRegisterResponseDTO;
-import com.partnerd.web.dto.clubDTO.ClubUpdateRequestDTO;
-import com.partnerd.web.dto.clubDTO.ClubUpdateResponseDTO;
+import com.partnerd.web.dto.clubDTO.*;
+import jakarta.validation.constraints.Null;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -108,6 +109,43 @@ public class ClubServiceImpl implements ClubService {
 
 
         return ClubConverter.toClubUpdateResponseDTO(updatedClub);
+    }
+
+    @Override
+    public List<ClubDTO> getClubs(Integer page, String sort, Long categoryID){
+
+        Pageable pageable = PageRequest.of(page, 12);
+        Page<Club> clubPage;
+
+        if(categoryID != null ){
+            //카테고리별 정렬처리
+            if("latest".equalsIgnoreCase(sort)){
+                clubPage = clubRepository.findByCategoryIdOrderByCreatedAtDesc(categoryID, pageable);
+
+            }
+            else{
+                clubPage = clubRepository.findByCategoryIdOrderByViewsDesc(categoryID, pageable);
+            }
+
+        } else {
+            //전체 정렬 처리
+            if("latest".equalsIgnoreCase(sort)){
+                clubPage = clubRepository.findAllByOrderByCreatedAtDesc(pageable);
+            }
+
+            else{
+                clubPage = clubRepository.findAllByOrderByViewsDesc(pageable);
+            }
+        }
+
+        //ClubConverter를 통해 Club을 ClubDTO로 변환시켜서 반환
+        return clubPage.stream()
+                .map(ClubConverter::toClubDTO)
+                .collect(Collectors.toList());
+
+
+
+
     }
 
 }

--- a/src/main/java/com/partnerd/web/controller/ClubRestController.java
+++ b/src/main/java/com/partnerd/web/controller/ClubRestController.java
@@ -4,10 +4,7 @@ import com.partnerd.apiPaylaod.ApiResponse;
 import com.partnerd.apiPaylaod.code.status.ErrorStatus;
 import com.partnerd.apiPaylaod.code.status.SuccessStatus;
 import com.partnerd.service.clubService.ClubService;
-import com.partnerd.web.dto.clubDTO.ClubRegisterRequestDTO;
-import com.partnerd.web.dto.clubDTO.ClubRegisterResponseDTO;
-import com.partnerd.web.dto.clubDTO.ClubUpdateRequestDTO;
-import com.partnerd.web.dto.clubDTO.ClubUpdateResponseDTO;
+import com.partnerd.web.dto.clubDTO.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -15,6 +12,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/partnerd")
@@ -63,5 +62,30 @@ public class ClubRestController {
             @ModelAttribute ClubUpdateRequestDTO requestDTO) {
         ClubUpdateResponseDTO response = clubService.updateClub(clubId, requestDTO);
         return ApiResponse.of(SuccessStatus._OK, response);
+    }
+
+    @GetMapping
+    @Operation(summary = "동아리 전체 조회 API", description = "파트너드 찾기 화면에 들어왔을 때 파트너드 목록을 반환하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 수정되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 데이터가 올바르지 않습니다.")
+    })
+
+    public ApiResponse<List<ClubDTO>> getClubs(
+
+            @RequestParam(name = "page")
+            @Parameter(description = "조회할 페이지 번호 (1부터 시작)", example = "1", required = true)
+            Integer page,
+
+            @RequestParam(defaultValue = "popular")
+            @Parameter(description = "정렬 기준 ('popular': 인기순, 'latest': 최신순)", example = "popular", required = false)
+            String sort,
+
+            @RequestParam(name = "categoryID")
+            @Parameter(description = "카테고리 ID (필터링에 사용)", example = "5", required = true)
+            Long categoryID
+    ){
+        List<ClubDTO> clubs = clubService.getClubs(page -1 ,sort,categoryID);
+        return ApiResponse.of(SuccessStatus._OK,clubs);
     }
 }

--- a/src/main/java/com/partnerd/web/dto/clubDTO/ClubDTO.java
+++ b/src/main/java/com/partnerd/web/dto/clubDTO/ClubDTO.java
@@ -1,0 +1,16 @@
+package com.partnerd.web.dto.clubDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public class ClubDTO {
+    private String profile;
+    private String name;
+    private String intro;
+
+
+}


### PR DESCRIPTION
# PR 템플릿

## #️⃣ 연관된 이슈

> ex) #36 



## 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?



## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

파트너드 찾기 화면에 접속했을때 사용할

파트너드 목록을 조회하는 API입니다.

(카테고리 ID, 정렬방식(최신순,인기순 중 택1, 기본은 인기순), page수를 요청받아
해당 조건에 부합하는 동아리를 12개씩 반환합니다.)


 



## 💬피드백을 받고 싶은 부분 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

쿼리dsl을 공부해봐야할 것 같아서
일단 정적쿼리로 구현했습니다 ! 

간단하게 parameter로 카테고리 id, page, 정렬방식을 받아서

해당하는 조건에 맞는 클럽들을 뽑아온 후 컨버터에서 dto로 바꾼 후 반환하는 간단한 방식입니다 !



### PR 특이 사항

> 어떤 부분에 리뷰어가 집중하면 좋을까요?
