### PR TITLE
[REFACTOR] 파트너드 등록시 동아리장 권한 부여 수정

### DIFF
--- a/src/main/java/com/partnerd/converter/ClubConverter.java
+++ b/src/main/java/com/partnerd/converter/ClubConverter.java
@@ -16,6 +16,7 @@ public class ClubConverter {
                 .profile(null) // 이미지 처리 미구현
                 .views(0L)
                 .contactMethodList(new ArrayList<>())
+                .clubMembers(new ArrayList<>())
                 .build();
 
     }

--- a/src/main/java/com/partnerd/repository/clubMemberRepository/ClubMemberRepository.java
+++ b/src/main/java/com/partnerd/repository/clubMemberRepository/ClubMemberRepository.java
@@ -3,5 +3,8 @@ package com.partnerd.repository.clubMemberRepository;
 import com.partnerd.domain.mapping.ClubMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
+    Optional<ClubMember> findClubMemberByClubIdAndMemberId(Long clubId, Long memberId);
 }

--- a/src/main/java/com/partnerd/service/clubService/ClubService.java
+++ b/src/main/java/com/partnerd/service/clubService/ClubService.java
@@ -6,9 +6,9 @@ import java.util.List;
 
 public interface ClubService {
     ClubRegisterResponseDTO registerClub(ClubRegisterRequestDTO dto);
-    void deleteClub(Long clubId);
+    void deleteClub(Long clubId, Long memberId);
 
-    ClubUpdateResponseDTO updateClub(Long clubId, ClubUpdateRequestDTO dto);
+    ClubUpdateResponseDTO updateClub(Long clubId, ClubUpdateRequestDTO dto, Long memberId);
 
     List<ClubDTO> getClubs(Integer page, String sort, Long categoryId);
 }

--- a/src/main/java/com/partnerd/service/clubService/impl/ClubServiceImpl.java
+++ b/src/main/java/com/partnerd/service/clubService/impl/ClubServiceImpl.java
@@ -3,12 +3,19 @@ package com.partnerd.service.clubService.impl;
 import com.partnerd.apiPaylaod.code.status.ErrorStatus;
 import com.partnerd.apiPaylaod.exception.handler.CategoryHandler;
 import com.partnerd.apiPaylaod.exception.handler.ClubHandler;
+import com.partnerd.apiPaylaod.exception.handler.ClubMemberHandler;
 import com.partnerd.converter.ClubConverter;
 import com.partnerd.domain.Category;
 import com.partnerd.domain.Club;
 import com.partnerd.domain.ContactMethod;
+import com.partnerd.domain.Member;
+import com.partnerd.domain.enums.ActiveType;
+import com.partnerd.domain.enums.ClubMemberRole;
+import com.partnerd.domain.mapping.ClubMember;
 import com.partnerd.repository.categoryRepository.CategoryRepository;
+import com.partnerd.repository.clubMemberRepository.ClubMemberRepository;
 import com.partnerd.repository.clubRepository.ClubRepository;
+import com.partnerd.repository.memberRepository.MemberRepository;
 import com.partnerd.service.clubService.ClubService;
 import com.partnerd.web.dto.clubDTO.*;
 import jakarta.validation.constraints.Null;
@@ -18,6 +25,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,10 +35,11 @@ public class ClubServiceImpl implements ClubService {
 
     private final ClubRepository clubRepository;
     private final CategoryRepository categoryRepository;
+    private final MemberRepository memberRepository;
+    private final ClubMemberRepository clubMemberRepository;
 
     @Override
     public ClubRegisterResponseDTO registerClub(ClubRegisterRequestDTO dto) {
-
 
 
         //DTO에서받은 카테고리 id로 카테고리 받아옴
@@ -59,17 +68,41 @@ public class ClubServiceImpl implements ClubService {
 
 
         }
+        // 멤버 ID로 멤버 조회
+        Member member = memberRepository.findById(dto.getMemberId())
+                .orElseThrow(() -> new ClubHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // ClubMember 객체 생성 및 설정
+        ClubMember clubMember = ClubMember.builder()
+                .role(ClubMemberRole.LEADER)
+                .status(ActiveType.ACTIVE)
+                .joined_date(new Date())
+                .club(club)
+                .member(member)
+                .build();
+
+        // Club의 ClubMembers 리스트에 추가
+        club.getClubMembers().add(clubMember);
+
+
 
         Club savedClub = clubRepository.save(club);
         return ClubConverter.toClubRegisterResponseDTO(savedClub);
     }
 
     @Override
-    public void deleteClub(Long clubId) {
+    public void deleteClub(Long clubId, Long memberId) {
 
         //클럽존재여부확인
         if (!clubRepository.existsById(clubId)) {
             throw new ClubHandler(ErrorStatus.CLUB_NOT_FOUND);
+        }
+
+        // 클럽 멤버 조회 및 리더 권한 확인
+        ClubMember clubMember = clubMemberRepository.findClubMemberByClubIdAndMemberId(clubId, memberId)
+                .orElseThrow(() -> new ClubHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        if (clubMember.getRole() != ClubMemberRole.LEADER) {
+            throw new ClubMemberHandler(ErrorStatus.CLUB_MEMBER_NOT_AUTHORIZED);
         }
 
         // Delete the club
@@ -77,11 +110,18 @@ public class ClubServiceImpl implements ClubService {
     }
 
     @Override
-    public ClubUpdateResponseDTO updateClub(Long clubId, ClubUpdateRequestDTO dto) {
+    public ClubUpdateResponseDTO updateClub(Long clubId, ClubUpdateRequestDTO dto, Long memberId) {
 
         //기존 클럽 정보가져오기
         Club existingClub = clubRepository.findById(clubId)
                 .orElseThrow(() -> new ClubHandler(ErrorStatus.CLUB_NOT_FOUND));
+
+        // 클럽 멤버 조회 및 리더 권한 확인
+        ClubMember clubMember = clubMemberRepository.findClubMemberByClubIdAndMemberId(clubId, memberId)
+                .orElseThrow(() -> new ClubHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        if (clubMember.getRole() != ClubMemberRole.LEADER) {
+            throw new ClubMemberHandler(ErrorStatus.CLUB_MEMBER_NOT_AUTHORIZED);
+        }
 
         //카테고리 정보 가져오기
         Category existingCategory = categoryRepository.findById(dto.getCategoryId())

--- a/src/main/java/com/partnerd/web/controller/ClubRestController.java
+++ b/src/main/java/com/partnerd/web/controller/ClubRestController.java
@@ -3,6 +3,7 @@ package com.partnerd.web.controller;
 import com.partnerd.apiPaylaod.ApiResponse;
 import com.partnerd.apiPaylaod.code.status.ErrorStatus;
 import com.partnerd.apiPaylaod.code.status.SuccessStatus;
+import com.partnerd.config.security.JwtTokenProvider;
 import com.partnerd.service.clubService.ClubService;
 import com.partnerd.web.dto.clubDTO.*;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,6 +22,7 @@ import java.util.List;
 public class ClubRestController {
 
     private final ClubService clubService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/register")
     @Operation(summary = "동아리 등록 API", description = "새로운 동아리를 등록하는 API입니다.")
@@ -29,7 +31,16 @@ public class ClubRestController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 데이터가 올바르지 않습니다.")
     })
     public ApiResponse<ClubRegisterResponseDTO> registerClub(
+            @RequestHeader("Authorization") String authorizationHeader,
             @ModelAttribute ClubRegisterRequestDTO requestDTO) {
+
+        // 1. JWT 토큰 추출
+        String token = authorizationHeader.replace("Bearer ", "");
+
+        // 2. 토큰에서 userId 추출
+        Long memberId = Long.valueOf(jwtTokenProvider.getClaims(token).getSubject());
+
+        // 3. 서비스 호출
         ClubRegisterResponseDTO response = clubService.registerClub(requestDTO);
         return ApiResponse.of(SuccessStatus._OK, response);
     }
@@ -43,8 +54,15 @@ public class ClubRestController {
     @Parameters({
             @Parameter(name = "clubId", description = "파트너드의 ID, path variable 입니다!")
     })
-    public ApiResponse<Void> deleteClub(@PathVariable Long clubId) {
-        clubService.deleteClub(clubId);
+    public ApiResponse<Void> deleteClub(@RequestHeader("Authorization") String authorizationHeader,@PathVariable Long clubId) {
+
+        // 1. JWT 토큰 추출
+        String token = authorizationHeader.replace("Bearer ", "");
+
+        // 2. 토큰에서 userId 추출
+        Long memberId = Long.valueOf(jwtTokenProvider.getClaims(token).getSubject());
+
+        clubService.deleteClub(clubId, memberId);
         return ApiResponse.of(SuccessStatus._OK, null);
     }
 
@@ -58,21 +76,29 @@ public class ClubRestController {
             @Parameter(name = "clubId", description = "파트너드의 ID, path variable 입니다!")
     })
     public ApiResponse<ClubUpdateResponseDTO> updateClub(
+            @RequestHeader("Authorization") String authorizationHeader,
             @PathVariable Long clubId,
             @ModelAttribute ClubUpdateRequestDTO requestDTO) {
-        ClubUpdateResponseDTO response = clubService.updateClub(clubId, requestDTO);
+        // 1. JWT 토큰 추출
+        String token = authorizationHeader.replace("Bearer ", "");
+
+        // 2. 토큰에서 userId 추출
+        Long memberId = Long.valueOf(jwtTokenProvider.getClaims(token).getSubject());
+
+
+        ClubUpdateResponseDTO response = clubService.updateClub(clubId, requestDTO,memberId);
         return ApiResponse.of(SuccessStatus._OK, response);
     }
 
     @GetMapping
     @Operation(summary = "동아리 전체 조회 API", description = "파트너드 찾기 화면에 들어왔을 때 파트너드 목록을 반환하는 API입니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 수정되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 조회되었습니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 데이터가 올바르지 않습니다.")
     })
 
     public ApiResponse<List<ClubDTO>> getClubs(
-
+            @RequestHeader("Authorization") String authorizationHeader,
             @RequestParam(name = "page")
             @Parameter(description = "조회할 페이지 번호 (1부터 시작)", example = "1", required = true)
             Integer page,
@@ -85,6 +111,12 @@ public class ClubRestController {
             @Parameter(description = "카테고리 ID (필터링에 사용)", example = "5", required = true)
             Long categoryID
     ){
+        // 1. JWT 토큰 추출
+        String token = authorizationHeader.replace("Bearer ", "");
+
+        // 2. 토큰에서 userId 추출
+        Long memberId = Long.valueOf(jwtTokenProvider.getClaims(token).getSubject());
+
         List<ClubDTO> clubs = clubService.getClubs(page -1 ,sort,categoryID);
         return ApiResponse.of(SuccessStatus._OK,clubs);
     }

--- a/src/main/java/com/partnerd/web/dto/clubDTO/ClubUpdateRequestDTO.java
+++ b/src/main/java/com/partnerd/web/dto/clubDTO/ClubUpdateRequestDTO.java
@@ -29,11 +29,6 @@ public class ClubUpdateRequestDTO {
     @Schema(description = "연락 방법 목록")
     private List<ContactMethodDTO> contactMethod;
 
-    @NotNull(message = "회원ID는 비어있을 수 없습니다!")
-    @Min(value = 1, message = "회원ID는 1 이상이어야 합니다!")
-    @Schema(description = "회원 ID", example = "1")
-    private Long memberId;
-
     @NotNull(message = "카테고리ID는 Null 일 수 없습니다!")
     @Min(value = 1, message = "카테고리ID는 1 이상이어야 합니다!")
     @Schema(description = "카테고리 ID", example = "2")


### PR DESCRIPTION
파트너드 (동아리) 등록 삭제 수정 API에 jwt토큰 추출 로직 추가


# PR 템플릿

## #️⃣ 연관된 이슈

> ex) #80 



## 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?



## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
<img width="865" alt="image" src="https://github.com/user-attachments/assets/ef383cfc-b217-48bf-bed6-0e147fdcbec0" />

기존 파트너드 등록/수정/삭제 API에서
jwt 토큰 추출을 통한 memberID획득 로직을 추가하였습니다.

<img width="901" alt="image" src="https://github.com/user-attachments/assets/e57e6b6e-fe0e-42d6-afa7-0431e1120b3a" />
동아리를 등록한 사람의 권한을 동아리장으로 설정되도록 수정하였습니다.


## 💬피드백을 받고 싶은 부분 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


에러핸들링.. 조언 주시면 감사하겠습니다 !



### PR 특이 사항

> 어떤 부분에 리뷰어가 집중하면 좋을까요?
