### PR TITLE
[FEAT] 마이페이지 팀페이지(파트너드) 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/partnerd/converter/ClubConverter.java
+++ b/src/main/java/com/partnerd/converter/ClubConverter.java
@@ -5,6 +5,7 @@ import com.partnerd.domain.Club;
 import com.partnerd.web.dto.clubDTO.*;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class ClubConverter {
 
@@ -51,5 +52,21 @@ public class ClubConverter {
                 club.getName(),
                 club.getIntro()
         );
+    }
+
+    // 파트너드 목록 조회(마이페이지)
+    public static ClubResponseDTO.ReadClubPreviewListDTO clubPreviewListDTO(List<Club> clubs) {
+        List<ClubResponseDTO.ClubPreviewDTO> clubPreviewDTOList = clubs.stream()
+                .map(club -> ClubResponseDTO.ClubPreviewDTO.builder()
+                        .profile(club.getProfile())
+                        .category(club.getCategory().getName()) // 카테고리 이름
+                        .name(club.getName())
+                        .intro(club.getIntro())
+                        .build())
+                .toList();
+
+        return ClubResponseDTO.ReadClubPreviewListDTO.builder()
+                .clubPreviewDTOList(clubPreviewDTOList)
+                .build();
     }
 }

--- a/src/main/java/com/partnerd/repository/clubMemberRepository/ClubMemberRepository.java
+++ b/src/main/java/com/partnerd/repository/clubMemberRepository/ClubMemberRepository.java
@@ -1,10 +1,19 @@
 package com.partnerd.repository.clubMemberRepository;
 
+import com.partnerd.domain.Club;
+import com.partnerd.domain.enums.ClubMemberRole;
 import com.partnerd.domain.mapping.ClubMember;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     Optional<ClubMember> findClubMemberByClubIdAndMemberId(Long clubId, Long memberId);
+
+    @Query("SELECT cm.club FROM ClubMember cm " +
+            "WHERE cm.member.id = :memberId AND cm.role IN :roles")
+    List<Club> findClubsByRole(@Param("memberId") Long memberId, @Param("roles") List<ClubMemberRole> roles);
 }

--- a/src/main/java/com/partnerd/service/clubService/ClubService.java
+++ b/src/main/java/com/partnerd/service/clubService/ClubService.java
@@ -1,5 +1,6 @@
 package com.partnerd.service.clubService;
 
+import com.partnerd.domain.Club;
 import com.partnerd.web.dto.clubDTO.*;
 
 import java.util.List;
@@ -11,4 +12,7 @@ public interface ClubService {
     ClubUpdateResponseDTO updateClub(Long clubId, ClubUpdateRequestDTO dto, Long memberId);
 
     List<ClubDTO> getClubs(Integer page, String sort, Long categoryId);
+
+    // 파트너드 목록 조회(마이페이지)
+    List<Club> getClubsByRole(Long memberId);
 }

--- a/src/main/java/com/partnerd/service/clubService/impl/ClubServiceImpl.java
+++ b/src/main/java/com/partnerd/service/clubService/impl/ClubServiceImpl.java
@@ -188,4 +188,9 @@ public class ClubServiceImpl implements ClubService {
 
     }
 
+    // 파트너드 목록 조회(마이페이지)
+    @Override
+    public List<Club> getClubsByRole(Long memberId) {
+        return clubMemberRepository.findClubsByRole(memberId, List.of(ClubMemberRole.LEADER, ClubMemberRole.OFFICER));
+    }
 }

--- a/src/main/java/com/partnerd/web/controller/ClubRestController.java
+++ b/src/main/java/com/partnerd/web/controller/ClubRestController.java
@@ -4,6 +4,8 @@ import com.partnerd.apiPaylaod.ApiResponse;
 import com.partnerd.apiPaylaod.code.status.ErrorStatus;
 import com.partnerd.apiPaylaod.code.status.SuccessStatus;
 import com.partnerd.config.security.JwtTokenProvider;
+import com.partnerd.converter.ClubConverter;
+import com.partnerd.domain.Club;
 import com.partnerd.service.clubService.ClubService;
 import com.partnerd.web.dto.clubDTO.*;
 import io.swagger.v3.oas.annotations.Operation;
@@ -119,5 +121,25 @@ public class ClubRestController {
 
         List<ClubDTO> clubs = clubService.getClubs(page -1 ,sort,categoryID);
         return ApiResponse.of(SuccessStatus._OK,clubs);
+    }
+
+
+    // 파트너드 목록 조회(마이페이지)
+    @GetMapping("/myPartnerdPosts")
+    @Operation(summary = "마이페이지 파트너드 목록 조회 API",description = "마이페이지의 팀관리 페이지에서 파트너드 목록을 조회하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+    })
+    public ApiResponse<ClubResponseDTO.ReadClubPreviewListDTO> getClubsByRole(@RequestHeader("Authorization") String authorizationHeader){
+        // 1. JWT 토큰 추출
+        String token = authorizationHeader.replace("Bearer ", "");
+
+        // 2. 토큰에서 userId 추출
+        Long memberId = Long.valueOf(jwtTokenProvider.getClaims(token).getSubject());
+
+        // 3. 서비스 호출
+        List<Club> clubs = clubService.getClubsByRole(memberId);
+
+       return ApiResponse.onSuccess(ClubConverter.clubPreviewListDTO(clubs));
     }
 }

--- a/src/main/java/com/partnerd/web/dto/clubDTO/ClubResponseDTO.java
+++ b/src/main/java/com/partnerd/web/dto/clubDTO/ClubResponseDTO.java
@@ -1,0 +1,31 @@
+package com.partnerd.web.dto.clubDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class ClubResponseDTO {
+    // 파트너드 목록 조회(마이페이지-한 칸씩)
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClubPreviewDTO {
+        private String profile;
+        private String category;
+        private String name;
+        private String intro;
+    }
+
+    // 파트너드 목록 조회(마이페이지)
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReadClubPreviewListDTO {
+        private List<ClubPreviewDTO> clubPreviewDTOList;
+    }
+}


### PR DESCRIPTION
# PR 템플릿

## #️⃣ 연관된 이슈

> #29 



## 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?



## 📝작업 내용

> 마이페이지에서 팀페이지를 목록을 조회하는 API를 구현하였습니다. 팀의 리더와 부리더에게만 해당 팀의 팀페이지가 조회되는 형태입니다.



## 💬피드백을 받고 싶은 부분 (선택)

쿼리문을 작성한 repository와 이를 사용하는 서비스 부분을 잘 작성한 건지 확신이 들지 않아 피드백 주시면 감사하겠습니다!
피드백 주시면 적극 반영하여 수정하도록 하겠습니다!!


### PR 특이 사항

> 어떤 부분에 리뷰어가 집중하면 좋을까요?
