### PR TITLE
[REFACTOR] 중복 요청/작성자 요청 제한 로직 추가 및 Club 데이터 즉시 조회를 위한 쿼리 수정

### DIFF
--- a/src/main/java/com/partnerd/apiPaylaod/code/status/ErrorStatus.java
+++ b/src/main/java/com/partnerd/apiPaylaod/code/status/ErrorStatus.java
@@ -63,6 +63,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 콜라보 요청 관련
     COLLAB_ASK_NOT_FOUND(HttpStatus.NOT_FOUND, "COLLABASK4001", "해당 콜라보레이션 요청이 없습니다."),
+    COLLAB_ASK_ALREADY_EXIST(HttpStatus.NOT_FOUND, "COLLABASK4002", "이미 요청한 콜라보레이션입니다."),
 
     // 동아리
     CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB4001","해당 동아리가 없습니다."),

--- a/src/main/java/com/partnerd/apiPaylaod/code/status/ErrorStatus.java
+++ b/src/main/java/com/partnerd/apiPaylaod/code/status/ErrorStatus.java
@@ -64,6 +64,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 콜라보 요청 관련
     COLLAB_ASK_NOT_FOUND(HttpStatus.NOT_FOUND, "COLLABASK4001", "해당 콜라보레이션 요청이 없습니다."),
     COLLAB_ASK_ALREADY_EXIST(HttpStatus.NOT_FOUND, "COLLABASK4002", "이미 요청한 콜라보레이션입니다."),
+    COLLAB_ASK_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "COLLABASK4003", "작성자는 자신의 글에 요청할 수 없습니다."),
 
     // 동아리
     CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB4001","해당 동아리가 없습니다."),

--- a/src/main/java/com/partnerd/config/security/SecurityConfig.java
+++ b/src/main/java/com/partnerd/config/security/SecurityConfig.java
@@ -45,7 +45,8 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(Arrays.asList(
                 "https://part-nerd-fe.vercel.app",
-                "http://localhost:3000"
+                "http://localhost:3000",
+                "http://localhost:3001"
         )); // 허용할 Origin 설정
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")); // 허용할 HTTP 메서드 설정
         configuration.setAllowedHeaders(Arrays.asList("*")); // 모든 헤더 허용

--- a/src/main/java/com/partnerd/domain/mapping/CollabAsk.java
+++ b/src/main/java/com/partnerd/domain/mapping/CollabAsk.java
@@ -1,5 +1,6 @@
 package com.partnerd.domain.mapping;
 
+import com.partnerd.domain.Club;
 import com.partnerd.domain.CollabPost;
 import com.partnerd.domain.common.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/partnerd/repository/clubMemberRepository/ClubMemberRepository.java
+++ b/src/main/java/com/partnerd/repository/clubMemberRepository/ClubMemberRepository.java
@@ -12,8 +12,11 @@ import java.util.Optional;
 
 public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     Optional<ClubMember> findClubMemberByClubIdAndMemberId(Long clubId, Long memberId);
-    
-  ClubMember findByMember_id(Long memberId);
+
+    @Query("SELECT cm FROM ClubMember cm " +
+            "LEFT JOIN FETCH cm.club c " +
+            "WHERE cm.member.id = :memberId")
+    ClubMember findByMemberIdWithClub(Long memberId);
 
     @Query("SELECT cm.club FROM ClubMember cm " +
             "WHERE cm.member.id = :memberId AND cm.role IN :roles")

--- a/src/main/java/com/partnerd/repository/collabAskRepository/CollabAskRepository.java
+++ b/src/main/java/com/partnerd/repository/collabAskRepository/CollabAskRepository.java
@@ -12,4 +12,5 @@ public interface CollabAskRepository extends JpaRepository<CollabAsk, Long>, Col
     @Query("SELECT c FROM CollabAsk c WHERE c.id = :collabAskId AND c.sender.member.id = :memberId")
     Optional<CollabAsk> findByIdAndSenderMemberId(@Param("collabAskId") Long collabAskId, @Param("memberId") Long memberId);
 
+   CollabAsk findBySender_Member_idAndCollabPost_id(Long memberId, Long collabPostId);
 }

--- a/src/main/java/com/partnerd/repository/collabAskRepository/CollabAskRepositoryCustomImpl.java
+++ b/src/main/java/com/partnerd/repository/collabAskRepository/CollabAskRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package com.partnerd.repository.collabAskRepository;
 
 import com.partnerd.domain.QClub;
+import com.partnerd.domain.QMember;
 import com.partnerd.domain.mapping.CollabAsk;
 import com.partnerd.domain.mapping.QClubMember;
 import com.partnerd.domain.mapping.QCollabAsk;
@@ -20,6 +21,7 @@ public class CollabAskRepositoryCustomImpl implements CollabAskRepositoryCustom{
     private final JPAQueryFactory queryFactory;
     private final QCollabAsk qCollabAsk = QCollabAsk.collabAsk;
     private final QClubMember qClubMember = QClubMember.clubMember;
+    private final QMember qMember = QMember.member;
     private final QClub qClub = QClub.club;
 
 
@@ -33,7 +35,9 @@ public class CollabAskRepositoryCustomImpl implements CollabAskRepositoryCustom{
                 .fetchJoin()
                 .leftJoin(qClubMember.club, qClub)
                 .fetchJoin()
-                .where(qCollabAsk.sender.member.id.eq(senderId));
+                .leftJoin(qClubMember.member, qMember)
+                .fetchJoin()
+                .where(qMember.id.eq(senderId));
 
         long total = query.fetch().size();
         List<CollabAsk> results = query.offset(pageable.getOffset()).limit(pageable.getPageSize()).fetch();
@@ -49,7 +53,9 @@ public class CollabAskRepositoryCustomImpl implements CollabAskRepositoryCustom{
                 .fetchJoin()
                 .leftJoin(qClubMember.club, qClub)
                 .fetchJoin()
-                .where(qCollabAsk.receiver.member.id.eq(senderId));
+                .leftJoin(qClubMember.member, qMember)
+                .fetchJoin()
+                .where(qMember.id.eq(senderId));
 
         long total = query.fetch().size();
         List<CollabAsk> results = query.offset(pageable.getOffset()).limit(pageable.getPageSize()).fetch();

--- a/src/main/java/com/partnerd/service/collabAskService/CollabAskCommandService.java
+++ b/src/main/java/com/partnerd/service/collabAskService/CollabAskCommandService.java
@@ -5,7 +5,7 @@ import com.partnerd.web.dto.collabDTO.request.CollabAskRequestDTO;
 
 public interface CollabAskCommandService {
 
-    CollabAsk addCollabAsk(CollabAskRequestDTO.addCollabAskRquestDTO requestDTO);
+    CollabAsk addCollabAsk(Long collabPostId, Long memberId);
     void deleteCollabAsk(Long collabAskId, Long memberId);
 
 }

--- a/src/main/java/com/partnerd/service/collabAskService/impl/CollabAskCommandServiceImpl.java
+++ b/src/main/java/com/partnerd/service/collabAskService/impl/CollabAskCommandServiceImpl.java
@@ -34,11 +34,16 @@ public class CollabAskCommandServiceImpl implements CollabAskCommandService {
     @Transactional
     public CollabAsk addCollabAsk(CollabAskRequestDTO.addCollabAskRquestDTO requestDTO) {
 
+        CollabAsk isCheckDuplication = collabAskRepository.findBySender_Member_idAndCollabPost_id(requestDTO.getSenderId(), requestDTO.getCollabPostId());
+        if(isCheckDuplication != null) {
+            throw new CollabAskHandler(ErrorStatus.COLLAB_ASK_ALREADY_EXIST);
+        }
+
         CollabPost collabPost = collabPostRepository.findByIdWithMember(requestDTO.getCollabPostId()).orElseThrow(() -> (
             new CollabPostHandler(ErrorStatus.COLLAB_POST_NOT_FOUND)));
 
-        // 보낸 사람 (동아리까지 함께 조회)
-        ClubMember sender = clubMemberRepository.findByMember_id(requestDTO.getSenderId());
+        // 보내는 사람 (동아리까지 함께 조회)
+        ClubMember sender = clubMemberRepository.findByMemberIdWithClub(requestDTO.getSenderId());
 
         if (sender == null) {
             throw new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND);

--- a/src/main/java/com/partnerd/service/collabAskService/impl/CollabAskCommandServiceImpl.java
+++ b/src/main/java/com/partnerd/service/collabAskService/impl/CollabAskCommandServiceImpl.java
@@ -32,18 +32,24 @@ public class CollabAskCommandServiceImpl implements CollabAskCommandService {
 
     @Override
     @Transactional
-    public CollabAsk addCollabAsk(CollabAskRequestDTO.addCollabAskRquestDTO requestDTO) {
+    public CollabAsk addCollabAsk(Long collabPostId, Long memberId) {
 
-        CollabAsk isCheckDuplication = collabAskRepository.findBySender_Member_idAndCollabPost_id(requestDTO.getSenderId(), requestDTO.getCollabPostId());
+        CollabPost collabPost = collabPostRepository.findByIdWithMember(collabPostId).orElseThrow(() -> (
+            new CollabPostHandler(ErrorStatus.COLLAB_POST_NOT_FOUND)));
+
+        // 요청자가 해당 글의 작성자이면 요청 불가
+        if (collabPost.getClubMember().getMember().getId() == memberId) {
+            throw new CollabAskHandler(ErrorStatus.COLLAB_ASK_NOT_AUTHORIZED);
+        }
+
+        // 내가 이미 보낸 요청인지 확인 (중복 요청 방지)
+        CollabAsk isCheckDuplication = collabAskRepository.findBySender_Member_idAndCollabPost_id(memberId, collabPostId);
         if(isCheckDuplication != null) {
             throw new CollabAskHandler(ErrorStatus.COLLAB_ASK_ALREADY_EXIST);
         }
 
-        CollabPost collabPost = collabPostRepository.findByIdWithMember(requestDTO.getCollabPostId()).orElseThrow(() -> (
-            new CollabPostHandler(ErrorStatus.COLLAB_POST_NOT_FOUND)));
-
         // 보내는 사람 (동아리까지 함께 조회)
-        ClubMember sender = clubMemberRepository.findByMemberIdWithClub(requestDTO.getSenderId());
+        ClubMember sender = clubMemberRepository.findByMemberIdWithClub(memberId);
 
         if (sender == null) {
             throw new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND);
@@ -63,7 +69,7 @@ public class CollabAskCommandServiceImpl implements CollabAskCommandService {
         CollabAsk newCollabAsk = collabAskRepository.save(collabAsk);
 
         CollabAskEvent event = CollabAskEvent.builder()
-                .receiverId(requestDTO.getSenderId())
+                .receiverId(memberId)
                 .clubName(sender.getClub().getName())
                 .CollabPostTitle(collabPost.getTitle())
                 .build();

--- a/src/main/java/com/partnerd/web/controller/collabAskController/CollabAskRestController.java
+++ b/src/main/java/com/partnerd/web/controller/collabAskController/CollabAskRestController.java
@@ -24,14 +24,14 @@ public class CollabAskRestController {
     private final CollabAskQueryService collabAskQueryService;
 
     // 콜라보 요청하기
-    @PostMapping("/")
+    @PostMapping("/{collabPostId}")
     @Operation(summary = "콜라보 요청 API", description = "콜라보 요청 할 수 있는 API입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
-    public ApiResponse<CollabAskResponseDTO.addCollabAskResponseDTO> addCollabAsk(@RequestBody CollabAskRequestDTO.addCollabAskRquestDTO requestDTO) {
+    public ApiResponse<CollabAskResponseDTO.addCollabAskResponseDTO> addCollabAsk(@PathVariable(name = "collabPostId")Long collabPostId, @RequestParam(name = "memberId")Long memberId) {
 
-        CollabAsk collabAsk = collabAskCommandService.addCollabAsk(requestDTO);
+        CollabAsk collabAsk = collabAskCommandService.addCollabAsk(collabPostId, memberId);
 
         return ApiResponse.onSuccess(CollabAskConverter.toAddCollabAskResponseDTO(collabAsk));
 


### PR DESCRIPTION
# PR 템플릿

## #️⃣ 연관된 이슈

> #90 


## 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?



## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 중복 요청을 할 수 없도록 제한하는 로직을 추가로 구현하였습니다.
- 콜라보 요청자가 해당 콜라보 작성자 일시 요청할 수 없도록 제한하는 로직을 추가로 구현하였습니다.
- 기존의 findByMember_id(Long memberId)를 @Query를 사용한 findByMemberIdWithClub(Long memberId)로 변경.

LEFT JOIN FETCH를 통해 Club 데이터를 함께 조회하도록 수정하였습니다.

-> N+1 문제를 방지하고, 성능 최적화



## 💬피드백을 받고 싶은 부분 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?




### PR 특이 사항

> 어떤 부분에 리뷰어가 집중하면 좋을까요?
