### PR TITLE
[REFACTOR] 콜라보 전체 조회 (카테고리 별 포함) 쿼리 수정

### DIFF
--- a/src/main/java/com/partnerd/repository/collabPostRepository/CollabPostRepositoryCustomImpl.java
+++ b/src/main/java/com/partnerd/repository/collabPostRepository/CollabPostRepositoryCustomImpl.java
@@ -3,9 +3,10 @@ package com.partnerd.repository.collabPostRepository;
 import com.partnerd.domain.*;
 import com.partnerd.domain.mapping.QClubMember;
 import com.partnerd.domain.mapping.QCollabPostCategory;
-import com.querydsl.core.QueryResults;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -33,7 +34,7 @@ public class CollabPostRepositoryCustomImpl implements CollabPostRepositoryCusto
     private final QCollabPostImg qCollabPostImg = QCollabPostImg.collabPostImg;
 
 
-    private void applySorting(JPAQuery<CollabPost> query, Pageable pageable) {
+    private PagingResultDTO applySortingAndPaging(JPAQuery<CollabPost> query, Pageable pageable) {
         Sort sort = pageable.getSort();
         for (Sort.Order order : sort) {
             String property = order.getProperty();
@@ -43,6 +44,21 @@ public class CollabPostRepositoryCustomImpl implements CollabPostRepositoryCusto
                 query.orderBy(qCollabPost.endDate.asc());
             }
         }
+        long total = queryFactory
+                .select(qCollabPost.count())
+                .from(qCollabPost)
+                .fetchOne();
+
+        List<CollabPost> results = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return PagingResultDTO.builder()
+                .total(total)
+                .results(results)
+                .build();
+
     }
 
     @Override
@@ -54,12 +70,9 @@ public class CollabPostRepositoryCustomImpl implements CollabPostRepositoryCusto
                 .leftJoin(qCollabPostCategory.category, qCategory) // Category도 즉시 로딩
                 .fetchJoin();
 
-       applySorting(query, pageable);
+       PagingResultDTO pagingResultDTO = applySortingAndPaging(query, pageable);
 
-        long total = query.fetch().size();
-        List<CollabPost> results = query.offset(pageable.getOffset()).limit(pageable.getPageSize()).fetch();
-
-        return new PageImpl<>(results, pageable, total);
+        return new PageImpl<>(pagingResultDTO.getResults(), pageable, pagingResultDTO.getTotal());
     }
 
 
@@ -73,15 +86,9 @@ public class CollabPostRepositoryCustomImpl implements CollabPostRepositoryCusto
                 .where(qCollabPost.collabPostCategoryList.any().category.id.in(categories))
                 .distinct();
 
-        applySorting(query, pageable);
+        PagingResultDTO pagingResultDTO = applySortingAndPaging(query, pageable);
 
-        QueryResults<CollabPost> queryResults = query
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetchResults();
-
-
-        return new PageImpl<>(queryResults.getResults(), pageable,  queryResults.getTotal());
+        return new PageImpl<>(pagingResultDTO.getResults(), pageable, pagingResultDTO.getTotal());
     }
 
 
@@ -131,4 +138,13 @@ public class CollabPostRepositoryCustomImpl implements CollabPostRepositoryCusto
                 .distinct()
                 .fetch();
     }
+
+
+    @Builder
+    @Getter
+    public static class PagingResultDTO {
+        private long total;
+        private List<CollabPost> results;
+    }
+
 }

--- a/src/main/java/com/partnerd/web/controller/collabPostController/CollabPostRestController.java
+++ b/src/main/java/com/partnerd/web/controller/collabPostController/CollabPostRestController.java
@@ -76,7 +76,8 @@ public class CollabPostRestController {
     // 콜라보 글 전체 조회 (최신순)
     @GetMapping("/")
     @Operation(summary = "콜라보 글 전체 조회 API (마감순, 최신순) ",
-            description = "콜라보 글 전체 조회 API입니다. page는 1부터 시작합니다.")
+            description = "콜라보 글 전체 조회 API입니다. page는 1부터 시작합니다." +
+                    "sortBy 는 정렬기준으로 기본값은 endDate(마감순) 입니다. createdAt 을 입력하면 콜라보 글 등록 최신순으로 정렬할 수 있습니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
     })
@@ -105,7 +106,8 @@ public class CollabPostRestController {
     // 카테고리 별 콜라보 글 조회
     @GetMapping("/categories")
     @Operation(summary = "콜라보 글 카테고리 별 조회 API (마감순, 최신순) ",
-            description = "콜라보 글 카테고리 별 조회 API입니다. page는 1부터 시작합니다.")
+            description = "콜라보 글 카테고리 별 조회 API입니다. page는 1부터 시작합니다." +
+                    "sortBy 는 정렬기준으로 기본값은 endDate(마감순) 입니다. createdAt 을 입력하면 콜라보 글 등록 최신순으로 정렬할 수 있습니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
     })


### PR DESCRIPTION
# PR 템플릿

## #️⃣ 연관된 이슈

> #99 



## 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?



## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)



<img width="458" alt="스크린샷 2025-01-27 오후 6 54 55" src="https://github.com/user-attachments/assets/f5efbf25-4292-499e-a940-ec25613f4881" />

1️⃣ 게시글 전체 조회 쿼리 중 Page<CollabPost> findAllWithCategories 메서드
total 계산을 효율적으로 하기 위해 전체 데이터를 메모리로 로드한 후 크기를 계산하기 때문에 성능 문제 있을 수 있는 fetch.size() 대신 
메모리로 데이터를 로드하지 않고, 데이터 베이스에서 효율적으로 처리하는 방식으로 변경

2️⃣ 카테고리 별 게시글 조회 쿼리 중 Page<CollabPost> findAllByCategories 메서드 
fetchResults()는 더 이상 최신 버전의 QueryDSL에서 권장되지 않고, 한 번에 데이터를 2번 로드하는 것보다 필요한 쿼리만 나가는 것이 가독성면에서나 쿼리 효율성 측면에서 더 낫다고 판단하여 fetchResults() 방식 -> count()와 fetch() 분리 방식으로 변경.

3️⃣ 중복 코드 메서드로 분리


## 💬피드백을 받고 싶은 부분 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?




### PR 특이 사항

> 어떤 부분에 리뷰어가 집중하면 좋을까요?
