### PR TITLE
[REFACTOR] 콜라보 글 생성 쿼리에서 불필요한 IN절 제거를 위해 쿼리 수정

### DIFF
--- a/src/main/java/com/partnerd/repository/categoryRepository/CategoryRepository.java
+++ b/src/main/java/com/partnerd/repository/categoryRepository/CategoryRepository.java
@@ -3,5 +3,5 @@ package com.partnerd.repository.categoryRepository;
 import com.partnerd.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CategoryRepository extends JpaRepository<Category, Long> {
+public interface CategoryRepository extends JpaRepository<Category, Long>, CategoryRepositoryCustom {
 }

--- a/src/main/java/com/partnerd/repository/categoryRepository/CategoryRepositoryCustom.java
+++ b/src/main/java/com/partnerd/repository/categoryRepository/CategoryRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.partnerd.repository.categoryRepository;
+
+import com.partnerd.domain.Category;
+
+import java.util.List;
+
+public interface CategoryRepositoryCustom {
+
+    List<Category> findAllByIdWithCollabPostCategory(List<Long> categoryIds);
+
+}

--- a/src/main/java/com/partnerd/repository/categoryRepository/CategoryRepositoryImpl.java
+++ b/src/main/java/com/partnerd/repository/categoryRepository/CategoryRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.partnerd.repository.categoryRepository;
+
+import com.partnerd.domain.Category;
+import com.partnerd.domain.QCategory;
+import com.partnerd.domain.mapping.QCollabPostCategory;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CategoryRepositoryImpl implements CategoryRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+    private final QCategory qCategory = QCategory.category;
+    private final QCollabPostCategory qCollabPostCategory = QCollabPostCategory.collabPostCategory;
+
+    @Override
+    public List<Category> findAllByIdWithCollabPostCategory(List<Long> categoryIds) {
+
+        List<Category> categoryList = queryFactory
+                .selectFrom(qCategory)
+                .leftJoin(qCategory.collabPostCategoryList, qCollabPostCategory).fetchJoin()
+                .where(qCategory.id.in(categoryIds))
+                .fetch();
+
+        return categoryList;
+    }
+}

--- a/src/main/java/com/partnerd/service/collabPostService/impl/CollabPostCommandServiceImpl.java
+++ b/src/main/java/com/partnerd/service/collabPostService/impl/CollabPostCommandServiceImpl.java
@@ -42,14 +42,7 @@ public class CollabPostCommandServiceImpl implements CollabPostCommandService {
 
         CollabPost collabPost = CollabPostConverter.toCollabPost(requestDTO);
         // 카테고리 객체 찾아서 리스트로 만들기
-        List<Category> categoryList =
-                requestDTO.getCategoryIds().stream()
-                        .map(categoryId ->{
-                            Category category = categoryRepository.findById(categoryId).orElseThrow(() ->
-                                    new CategoryHandler(ErrorStatus.CATEGORY_NOT_FOUND));
-                            return category;
-                        })
-                        .collect(Collectors.toList());
+        List<Category> categoryList = categoryRepository.findAllByIdWithCollabPostCategory(requestDTO.getCategoryIds());
 
         // CollabPostCategory 리스트를 컨버터를 통해서 빌더로 만들어 생성하고 양방향 관계 설정
         List<CollabPostCategory> collabPostCategoryList = CollapPostCategoryConverter.


### PR DESCRIPTION
# PR 템플릿

## #️⃣ 연관된 이슈

> #100 



## 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?



## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

<img width="1443" alt="스크린샷 2025-01-28 오후 6 12 20" src="https://github.com/user-attachments/assets/f84ebb93-788d-478f-afab-ada5761d973b" />

- 카테고리 아이디 별로 하나씩 쿼리를 실행하는 방식에서 전체 아이디를 통해서 해당하는 카테고리들을 리스트로 반환하는 쿼리로 수정

<img width="1159" alt="스크린샷 2025-01-27 오후 7 15 12" src="https://github.com/user-attachments/assets/5c167b4e-4454-4d51-bc1b-d1c949879119" />

- CollabPostCategory 와의 양항뱡 매핑시 Category 의 CollabPostCategory를 로드할 때, 불필요한 IN절 방지를 위해 
카테고리들을 리스트로 반환 쿼리에서 CollabPostCategory 도 함께 로드 되도록 FETCH JOIN 사용.

## 💬피드백을 받고 싶은 부분 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?




### PR 특이 사항

> 어떤 부분에 리뷰어가 집중하면 좋을까요?
