### PR TITLE
[REFACTOR] 콜라보 글과 콜라보 요청 연관관계 양방향매핑

### DIFF
--- a/src/main/java/com/partnerd/domain/CollabPost.java
+++ b/src/main/java/com/partnerd/domain/CollabPost.java
@@ -2,6 +2,7 @@ package com.partnerd.domain;
 
 import com.partnerd.domain.common.BaseEntity;
 import com.partnerd.domain.mapping.ClubMember;
+import com.partnerd.domain.mapping.CollabAsk;
 import com.partnerd.domain.mapping.CollabPostCategory;
 import com.partnerd.web.dto.collabDTO.request.CollabPostRequestDTO;
 import jakarta.persistence.*;
@@ -82,7 +83,10 @@ public class CollabPost extends BaseEntity {
     // 배너 및 메인, 행사 사진
     @OneToMany(mappedBy = "collabPost", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<CollabPostImg> collabPostImgList = new LinkedHashSet<>();
-    
+
+    // 콜라보 요청
+    @OneToMany(mappedBy = "collabPost", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CollabAsk> collabAskList = new ArrayList<>();
 
     public void setClubMember(ClubMember addClubMember) {
         if (this.clubMember != null) {

--- a/src/main/java/com/partnerd/repository/collabPostRepository/EventTypeRepository.java
+++ b/src/main/java/com/partnerd/repository/collabPostRepository/EventTypeRepository.java
@@ -6,6 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface EventTypeRepository extends JpaRepository<EventType, Long> {
-    Optional<EventType> findById(Long id);
 
 }

--- a/src/main/java/com/partnerd/service/collabPostService/impl/CollabPostQueryServiceImpl.java
+++ b/src/main/java/com/partnerd/service/collabPostService/impl/CollabPostQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package com.partnerd.service.collabPostService.impl;
 
+import com.partnerd.apiPaylaod.code.status.ErrorStatus;
+import com.partnerd.apiPaylaod.exception.handler.CollabPostHandler;
 import com.partnerd.domain.CollabPost;
 import com.partnerd.repository.collabPostRepository.CollabPostRepository;
 import com.partnerd.service.collabPostService.CollabPostQueryService;
@@ -43,7 +45,12 @@ public class CollabPostQueryServiceImpl implements CollabPostQueryService {
     @Transactional(readOnly=true)
     public CollabPost getCollabPost(Long collabPostId) {
 
-        return collabPostRepository.findCollabPostDetails(collabPostId);
+        CollabPost collabPost = collabPostRepository.findCollabPostDetails(collabPostId);
+        if (collabPost == null) {
+            throw new CollabPostHandler(ErrorStatus.COLLAB_POST_NOT_FOUND);
+        }
+
+        return collabPost;
     }
 
 

--- a/src/main/java/com/partnerd/web/controller/collabPostController/CollabPostRestController.java
+++ b/src/main/java/com/partnerd/web/controller/collabPostController/CollabPostRestController.java
@@ -51,11 +51,12 @@ public class CollabPostRestController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
     })
-    public ApiResponse<CollabPostResponseDTO.addCollabPostResultDTO> modifyCollabPost( @PathVariable Long collabPostId, @RequestBody CollabPostRequestDTO.RequestCollabPostDTO requestDTO) {
+    public ApiResponse<CollabPostResponseDTO.addCollabPostResultDTO> modifyCollabPost(@PathVariable Long collabPostId, @RequestBody CollabPostRequestDTO.RequestCollabPostDTO requestDTO) {
 
         if (requestDTO.getBannerKeyName() == null || requestDTO.getMainKeyName() == null) {
             throw new CollabPostHandler(ErrorStatus.COLLAB_POST_BAD_REQUEST);
         }
+
 
         CollabPost collabPost = collabPostCommandService.modifyCollabPost(collabPostId, requestDTO);
         return ApiResponse.onSuccess(CollabPostConverter.toCollabPostResultDTO(collabPost));


### PR DESCRIPTION
# PR 템플릿

## #️⃣ 연관된 이슈

> #101 



## 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?



## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 콜라보 글 삭제 시 외래키제약조건으로 자식 객체인 콜라보 요청을 모두 삭제하기 위해 양방향 매핑 설정
- Spring Data JPA의 기본 메서드는 Hibernate의 EntityManager를 사용해 단순한 WHERE id = ? 쿼리를 생성하므로 IN 구문이 포함되지 않음. 하지만 직접 정의한 findById는 Hibernate 에서 내부적으로 상속 구조일 때, 여러 하위 클래스를 처리할 준비를 하면서 복잡한 쿼리를 생성하기 때문에 불필요한 IN 구문 발생 -> 정의 메서드에서 기본 메서드로 변경!

## 💬피드백을 받고 싶은 부분 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?




### PR 특이 사항

> 어떤 부분에 리뷰어가 집중하면 좋을까요?
