### PR TITLE
[REFACTOR ] 파트너드 조회 API 수정(카테고리id, clubId)

### DIFF
--- a/src/main/java/com/partnerd/converter/clubConverter/ClubConverter.java
+++ b/src/main/java/com/partnerd/converter/clubConverter/ClubConverter.java
@@ -57,6 +57,7 @@ public class ClubConverter {
                 .orElse(null); // 없으면 null 반환
 
         return new ClubDTO(
+                club.getId(),
                 profileImage,
                 club.getName(),
                 club.getIntro()

--- a/src/main/java/com/partnerd/repository/clubRepository/ClubRepositoryCustom.java
+++ b/src/main/java/com/partnerd/repository/clubRepository/ClubRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.partnerd.repository.clubRepository;
 
+import com.partnerd.web.dto.clubDTO.ClubDTO;
 import com.partnerd.web.dto.homeDTO.response.HomeClubDTO;
 import org.springframework.data.domain.Pageable;
 
@@ -7,5 +8,6 @@ import java.util.List;
 
 public interface ClubRepositoryCustom {
     List<HomeClubDTO> findTopClubs(Pageable pageable);
+    List<ClubDTO> findClubsByFilters(Integer page, String sort, Long categoryID);
 }
 

--- a/src/main/java/com/partnerd/repository/clubRepository/ClubRepositoryCustomImpl.java
+++ b/src/main/java/com/partnerd/repository/clubRepository/ClubRepositoryCustomImpl.java
@@ -4,8 +4,10 @@ import com.partnerd.domain.QCategory;
 import com.partnerd.domain.QClub;
 import com.partnerd.domain.QClubImage;
 import com.partnerd.domain.enums.ImageType;
+import com.partnerd.web.dto.clubDTO.ClubDTO;
 import com.partnerd.web.dto.homeDTO.response.HomeClubDTO;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -40,4 +42,31 @@ public class ClubRepositoryCustomImpl implements ClubRepositoryCustom {
                 .limit(pageable.getPageSize()) // 🔥 상위 3개 제한
                 .fetch();
     }
+
+    @Override
+    public List<ClubDTO> findClubsByFilters(Integer page, String sort, Long categoryID) {
+        QClub club = QClub.club;
+        QClubImage clubImage = QClubImage.clubImage;
+
+        JPAQuery<ClubDTO> query = queryFactory
+                .select(Projections.constructor(ClubDTO.class,
+                        club.id,
+                        clubImage.keyName, // null 허용
+                        club.name,
+                        club.intro
+                ))
+                .from(club)
+                .leftJoin(club.clubImgList, clubImage)
+                .on(clubImage.image_type.eq(ImageType.MAIN)) // MAIN 이미지만 가져오기
+                .where(categoryID != null && categoryID > 0 ? club.category.id.eq(categoryID) : null) // 카테고리 필터
+                .orderBy(
+                        "latest".equalsIgnoreCase(sort) ? club.createdAt.desc() : club.views.desc()
+                )
+                .offset(page * 12) // 페이지네이션 적용
+                .limit(12);
+
+        return query.fetch();
+    }
+
+
 }

--- a/src/main/java/com/partnerd/service/clubService/impl/ClubServiceImpl.java
+++ b/src/main/java/com/partnerd/service/clubService/impl/ClubServiceImpl.java
@@ -194,41 +194,11 @@ public class ClubServiceImpl implements ClubService {
         return ClubConverter.toClubUpdateResponseDTO(existingClub);
     }
 
-
+    //파트너드 목록 조회
     @Override
     public List<ClubDTO> getClubs(Integer page, String sort, Long categoryID){
 
-        Pageable pageable = PageRequest.of(page, 12);
-        Page<Club> clubPage;
-
-        if(categoryID != null ){
-            //카테고리별 정렬처리
-            if("latest".equalsIgnoreCase(sort)){
-                clubPage = clubRepository.findByCategoryIdOrderByCreatedAtDesc(categoryID, pageable);
-
-            }
-            else{
-                clubPage = clubRepository.findByCategoryIdOrderByViewsDesc(categoryID, pageable);
-            }
-
-        } else {
-            //전체 정렬 처리
-            if("latest".equalsIgnoreCase(sort)){
-                clubPage = clubRepository.findAllByOrderByCreatedAtDesc(pageable);
-            }
-
-            else{
-                clubPage = clubRepository.findAllByOrderByViewsDesc(pageable);
-            }
-        }
-
-        //ClubConverter를 통해 Club을 ClubDTO로 변환시켜서 반환
-        return clubPage.stream()
-                .map(ClubConverter::toClubDTO)
-                .collect(Collectors.toList());
-
-
-
+        return clubRepository.findClubsByFilters(page, sort, categoryID);
 
     }
 

--- a/src/main/java/com/partnerd/web/controller/clubController/ClubRestController.java
+++ b/src/main/java/com/partnerd/web/controller/clubController/ClubRestController.java
@@ -105,11 +105,12 @@ public class ClubRestController {
             Integer page,
 
             @RequestParam(defaultValue = "popular")
-            @Parameter(description = "정렬 기준 ('popular': 인기순, 'latest': 최신순)", example = "popular", required = false)
+            @Parameter(description = "정렬 기준 ('popular': 인기순, 'latest': 최신순, 기본은 인기순입니다.)",
+                    example = "popular", required = false)
             String sort,
 
-            @RequestParam(name = "categoryID")
-            @Parameter(description = "카테고리 ID (필터링에 사용)", example = "5", required = true)
+            @RequestParam(name = "categoryID", required = false) //
+            @Parameter(description = "카테고리 ID (필터링에 사용, null이면 전체 조회)", example = "5", required = false)
             Long categoryID
     ){
         // 1. JWT 토큰 추출

--- a/src/main/java/com/partnerd/web/dto/clubDTO/ClubDTO.java
+++ b/src/main/java/com/partnerd/web/dto/clubDTO/ClubDTO.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @AllArgsConstructor
 public class ClubDTO {
-    private String profileImage;
+    private Long clubId;
+    private String profileImage;  //keyname
     private String name;
     private String intro;
 


### PR DESCRIPTION
카테고리ID 필수X , 동아리Id 반환하도록


# PR 템플릿

## #️⃣ 연관된 이슈

> ex) #160 



## 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?



## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
<img width="899" alt="image" src="https://github.com/user-attachments/assets/669439bb-8ac0-4c9f-8619-97181809f46b" />

기존 파트너드 목록조회 API에서  카테고리ID를 필수가 아니도록 하여 전체카테고리조회를 반영
반환값에 clubId를 추가하였습니다.


## 💬피드백을 받고 싶은 부분 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?




### PR 특이 사항

> 어떤 부분에 리뷰어가 집중하면 좋을까요?
