### PR TITLE
[FEAT]파트너드 상세 조회(팀페이지) API 구현

### DIFF
--- a/src/main/java/com/partnerd/repository/clubRepository/ClubRepositoryCustom.java
+++ b/src/main/java/com/partnerd/repository/clubRepository/ClubRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.partnerd.repository.clubRepository;
 
 import com.partnerd.web.dto.clubDTO.ClubDTO;
+import com.partnerd.web.dto.clubDTO.ClubDetailResponseDTO;
 import com.partnerd.web.dto.homeDTO.response.HomeClubDTO;
 import org.springframework.data.domain.Pageable;
 
@@ -9,5 +10,7 @@ import java.util.List;
 public interface ClubRepositoryCustom {
     List<HomeClubDTO> findTopClubs(Pageable pageable);
     List<ClubDTO> findClubsByFilters(Integer page, String sort, Long categoryID);
+
+    ClubDetailResponseDTO findClubDetails(Long clubId, Long memberId);
 }
 

--- a/src/main/java/com/partnerd/repository/clubRepository/ClubRepositoryCustomImpl.java
+++ b/src/main/java/com/partnerd/repository/clubRepository/ClubRepositoryCustomImpl.java
@@ -1,19 +1,27 @@
 package com.partnerd.repository.clubRepository;
 
-import com.partnerd.domain.QCategory;
-import com.partnerd.domain.QClub;
-import com.partnerd.domain.QClubImage;
+import com.partnerd.apiPaylaod.code.status.ErrorStatus;
+import com.partnerd.apiPaylaod.exception.handler.ClubHandler;
+import com.partnerd.domain.*;
+import com.partnerd.domain.enums.ClubMemberRole;
 import com.partnerd.domain.enums.ImageType;
-import com.partnerd.web.dto.clubDTO.ClubDTO;
+import com.partnerd.domain.mapping.QClubMember;
+import com.partnerd.web.dto.clubDTO.*;
+import com.partnerd.web.dto.contactMethodDTO.ContactMethodDTO;
 import com.partnerd.web.dto.homeDTO.response.HomeClubDTO;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -67,6 +75,144 @@ public class ClubRepositoryCustomImpl implements ClubRepositoryCustom {
 
         return query.fetch();
     }
+
+    @Override
+    public ClubDetailResponseDTO findClubDetails(Long clubId, Long memberId) {
+        QClub club = QClub.club;
+        QClubImage clubImage = QClubImage.clubImage;
+        QClubMember clubMember = QClubMember.clubMember;
+        QMember member = QMember.member;
+        QContactMethod contactMethod = QContactMethod.contactMethod;
+        QClubActivity clubActivity = QClubActivity.clubActivity;
+        QClubActivityImage clubActivityImage = QClubActivityImage.clubActivityImage;
+        QCollabPost collabPost = QCollabPost.collabPost;
+
+        // 🔥 1. 클럽 기본 정보 + 리더 여부 조회
+        Tuple result = queryFactory
+                .select(
+                        club.id,
+                        club.name,
+                        club.category.name,
+                        club.intro,
+                        clubMember.role,
+                        clubMember.member.id
+                )
+                .from(club)
+                .leftJoin(club.clubMembers, clubMember)
+                .on(clubMember.member.id.eq(memberId))
+                .where(club.id.eq(clubId))
+                .fetchOne();
+
+        if (result == null) {
+            throw new ClubHandler(ErrorStatus.CLUB_NOT_FOUND);
+        }
+
+        Long clubIdResult = result.get(club.id);
+        String clubName = result.get(club.name);
+        String categoryName = result.get(club.category.name);
+        String intro = result.get(club.intro);
+        boolean isLeader = result.get(clubMember.role) == ClubMemberRole.LEADER || result.get(clubMember.role) == ClubMemberRole.OFFICER;
+
+        // 🔥 2. 프로필 이미지 & 배너 이미지 조회
+        String profileImage = queryFactory
+                .select(clubImage.keyName)
+                .from(clubImage)
+                .where(clubImage.club.id.eq(clubId)
+                        .and(clubImage.image_type.eq(ImageType.MAIN)))
+                .orderBy(clubImage.createdAt.desc()) // 최신 이미지 선택
+                .fetchOne();
+
+        String bannerImage = queryFactory
+                .select(clubImage.keyName)
+                .from(clubImage)
+                .where(clubImage.club.id.eq(clubId)
+                        .and(clubImage.image_type.eq(ImageType.BANNER)))
+                .orderBy(clubImage.createdAt.desc()) // 최신 이미지 선택
+                .fetchOne();
+
+        // 🔥 3. 연락 방법 조회
+        List<ContactMethodDTO> contactMethods = queryFactory
+                .select(Projections.constructor(ContactMethodDTO.class,
+                        contactMethod.contactType,
+                        contactMethod.contactUrl))
+                .from(contactMethod)
+                .where(contactMethod.club.id.eq(clubId))
+                .fetch();
+
+        // 🔥 4. 활동 정보 조회
+        String activityIntro = queryFactory
+                .select(clubActivity.intro)
+                .from(clubActivity)
+                .where(clubActivity.club.id.eq(clubId))
+                .fetchOne();
+
+        List<String> activityImageKeyNames = Optional.ofNullable(
+                queryFactory.select(clubActivityImage.keyName)
+                        .from(clubActivityImage)
+                        .where(clubActivityImage.clubActivity.club.id.eq(clubId))
+                        .fetch()
+        ).orElse(Collections.emptyList());
+
+        ClubActivityDTO activityDTO = new ClubActivityDTO(activityIntro, activityImageKeyNames);
+
+        // 🔥 5. 멤버 리스트 조회 (최대 5명)
+        List<ClubDetailMemberDTO> leaderMembers = queryFactory
+                .select(Projections.constructor(ClubDetailMemberDTO.class,
+                        member.name,
+                        clubMember.role.stringValue(),
+                        member.occupation_of_interest,
+                        club.name))
+                .from(clubMember)
+                .leftJoin(clubMember.member, member)
+                .where(clubMember.club.id.eq(clubId)
+                        .and(clubMember.role.in(ClubMemberRole.LEADER, ClubMemberRole.OFFICER)))
+                .limit(5)
+                .fetch();
+
+        List<ClubDetailMemberDTO> generalMembers = queryFactory
+                .select(Projections.constructor(ClubDetailMemberDTO.class,
+                        member.name,
+                        clubMember.role.stringValue(),
+                        member.occupation_of_interest,
+                        club.name))
+                .from(clubMember)
+                .leftJoin(clubMember.member, member)
+                .where(clubMember.club.id.eq(clubId)
+                        .and(clubMember.role.eq(ClubMemberRole.MEMBER)))
+                .limit(5)
+                .fetch();
+
+        // 🔥 6. 콜라보 리스트 조회 (최대 5개, 최신순 정렬)
+        List<ClubDetailCollabDTO> collabPosts = queryFactory
+                .select(Projections.constructor(ClubDetailCollabDTO.class,
+                        collabPost.title,
+                        collabPost.description,
+                        collabPost.openDate))
+                .from(collabPost)
+                .leftJoin(collabPost.clubMember, clubMember)
+                .where(clubMember.club.id.eq(clubId))
+                .orderBy(collabPost.createdAt.desc())
+                .limit(5)
+                .fetch();
+
+        // 🔥 7. DTO 변환 후 반환
+        return new ClubDetailResponseDTO(
+                clubIdResult,
+                clubName,
+                categoryName,
+                intro,
+                profileImage,
+                bannerImage,
+                contactMethods,
+                activityDTO,
+                leaderMembers,
+                generalMembers,
+                collabPosts,
+                isLeader
+        );
+    }
+
+
 
 
 }

--- a/src/main/java/com/partnerd/repository/clubRepository/ClubRepositoryCustomImpl.java
+++ b/src/main/java/com/partnerd/repository/clubRepository/ClubRepositoryCustomImpl.java
@@ -87,7 +87,7 @@ public class ClubRepositoryCustomImpl implements ClubRepositoryCustom {
         QClubActivityImage clubActivityImage = QClubActivityImage.clubActivityImage;
         QCollabPost collabPost = QCollabPost.collabPost;
 
-        // 🔥 1. 클럽 기본 정보 + 리더 여부 조회
+        // 1. 클럽 기본 정보 + 리더 여부 조회
         Tuple result = queryFactory
                 .select(
                         club.id,
@@ -113,7 +113,7 @@ public class ClubRepositoryCustomImpl implements ClubRepositoryCustom {
         String intro = result.get(club.intro);
         boolean isLeader = result.get(clubMember.role) == ClubMemberRole.LEADER || result.get(clubMember.role) == ClubMemberRole.OFFICER;
 
-        // 🔥 2. 프로필 이미지 & 배너 이미지 조회
+        // 2. 프로필 이미지 & 배너 이미지 조회
         String profileImage = queryFactory
                 .select(clubImage.keyName)
                 .from(clubImage)
@@ -130,7 +130,7 @@ public class ClubRepositoryCustomImpl implements ClubRepositoryCustom {
                 .orderBy(clubImage.createdAt.desc()) // 최신 이미지 선택
                 .fetchOne();
 
-        // 🔥 3. 연락 방법 조회
+        // 3. 연락 방법 조회
         List<ContactMethodDTO> contactMethods = queryFactory
                 .select(Projections.constructor(ContactMethodDTO.class,
                         contactMethod.contactType,
@@ -139,7 +139,7 @@ public class ClubRepositoryCustomImpl implements ClubRepositoryCustom {
                 .where(contactMethod.club.id.eq(clubId))
                 .fetch();
 
-        // 🔥 4. 활동 정보 조회
+        // 4. 활동 정보 조회
         String activityIntro = queryFactory
                 .select(clubActivity.intro)
                 .from(clubActivity)
@@ -155,7 +155,7 @@ public class ClubRepositoryCustomImpl implements ClubRepositoryCustom {
 
         ClubActivityDTO activityDTO = new ClubActivityDTO(activityIntro, activityImageKeyNames);
 
-        // 🔥 5. 멤버 리스트 조회 (최대 5명)
+        // 5. 멤버 리스트 조회 (최대 5명)
         List<ClubDetailMemberDTO> leaderMembers = queryFactory
                 .select(Projections.constructor(ClubDetailMemberDTO.class,
                         member.name,
@@ -182,7 +182,7 @@ public class ClubRepositoryCustomImpl implements ClubRepositoryCustom {
                 .limit(5)
                 .fetch();
 
-        // 🔥 6. 콜라보 리스트 조회 (최대 5개, 최신순 정렬)
+        // 6. 콜라보 리스트 조회 (최대 5개, 최신순 정렬)
         List<ClubDetailCollabDTO> collabPosts = queryFactory
                 .select(Projections.constructor(ClubDetailCollabDTO.class,
                         collabPost.title,
@@ -195,7 +195,7 @@ public class ClubRepositoryCustomImpl implements ClubRepositoryCustom {
                 .limit(5)
                 .fetch();
 
-        // 🔥 7. DTO 변환 후 반환
+        // 7. DTO 변환 후 반환
         return new ClubDetailResponseDTO(
                 clubIdResult,
                 clubName,
@@ -210,6 +210,7 @@ public class ClubRepositoryCustomImpl implements ClubRepositoryCustom {
                 collabPosts,
                 isLeader
         );
+
     }
 
 

--- a/src/main/java/com/partnerd/service/clubService/ClubService.java
+++ b/src/main/java/com/partnerd/service/clubService/ClubService.java
@@ -13,6 +13,9 @@ public interface ClubService {
 
     List<ClubDTO> getClubs(Integer page, String sort, Long categoryId);
 
+    // 파트너드 상세조회 (팀페이지)
+    ClubDetailResponseDTO findClubDetails(Long clubId, Long memberId);
+
     // 파트너드 목록 조회(마이페이지)
     List<Club> getClubsByRole(Long memberId);
 }

--- a/src/main/java/com/partnerd/service/clubService/impl/ClubServiceImpl.java
+++ b/src/main/java/com/partnerd/service/clubService/impl/ClubServiceImpl.java
@@ -6,7 +6,6 @@ import com.partnerd.apiPaylaod.exception.handler.ClubHandler;
 import com.partnerd.apiPaylaod.exception.handler.ClubMemberHandler;
 import com.partnerd.converter.clubConverter.ClubConverter;
 import com.partnerd.domain.*;
-import com.partnerd.domain.enums.ActiveType;
 import com.partnerd.domain.enums.ClubMemberRole;
 import com.partnerd.domain.enums.ImageType;
 import com.partnerd.domain.mapping.ClubMember;
@@ -19,17 +18,10 @@ import com.partnerd.repository.memberRepository.MemberRepository;
 import com.partnerd.service.clubService.ClubService;
 import com.partnerd.web.dto.clubDTO.*;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -200,6 +192,12 @@ public class ClubServiceImpl implements ClubService {
 
         return clubRepository.findClubsByFilters(page, sort, categoryID);
 
+    }
+
+    // 파트너드 상세조회 (팀페이지)
+    @Override
+    public ClubDetailResponseDTO findClubDetails(Long clubId, Long memberId) {
+        return clubRepository.findClubDetails(clubId, memberId);
     }
 
     // 파트너드 목록 조회(마이페이지)

--- a/src/main/java/com/partnerd/web/controller/clubController/ClubRestController.java
+++ b/src/main/java/com/partnerd/web/controller/clubController/ClubRestController.java
@@ -123,6 +123,32 @@ public class ClubRestController {
         return ApiResponse.of(SuccessStatus._OK,clubs);
     }
 
+    @GetMapping("/{clubId}")
+    @Operation(summary = "동아리 상세 조회 API", description = "특정 동아리의 상세 정보를 조회하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 조회되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 동아리입니다.")
+    })
+    @Parameters({
+            @Parameter(name = "clubId", description = "조회할 동아리의 ID, path variable 입니다!")
+    })
+    public ApiResponse<ClubDetailResponseDTO> getClubDetails(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @PathVariable Long clubId) {
+
+        // 1. JWT 토큰 추출
+        String token = authorizationHeader.replace("Bearer ", "");
+
+        // 2. 토큰에서 userId 추출
+        Long memberId = Long.valueOf(jwtTokenProvider.getClaims(token).getSubject());
+
+        // 3. 서비스 호출
+        ClubDetailResponseDTO response = clubService.findClubDetails(clubId, memberId);
+
+        return ApiResponse.of(SuccessStatus._OK, response);
+    }
+
+
 
     // 파트너드 목록 조회(마이페이지)
     @GetMapping("/myPartnerdPosts")

--- a/src/main/java/com/partnerd/web/dto/clubDTO/ClubActivityDTO.java
+++ b/src/main/java/com/partnerd/web/dto/clubDTO/ClubActivityDTO.java
@@ -2,11 +2,13 @@ package com.partnerd.web.dto.clubDTO;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
 @Data
 @Schema(description = "클럽 활동 등록 DTO")
+
 public class ClubActivityDTO {
 
     @Schema(description = "활동 소개", example = "우리 동아리는 이런 활동에 참여했어요!")
@@ -14,4 +16,9 @@ public class ClubActivityDTO {
 
     @Schema(description = "활동 이미지 keyNames")
     private List<String> activityImageKeyNames;
+
+    public ClubActivityDTO(String intro, List<String> activityImageKeyNames) {
+        this.intro = intro;
+        this.activityImageKeyNames = activityImageKeyNames;
+    }
 }

--- a/src/main/java/com/partnerd/web/dto/clubDTO/ClubDetailCollabDTO.java
+++ b/src/main/java/com/partnerd/web/dto/clubDTO/ClubDetailCollabDTO.java
@@ -1,0 +1,13 @@
+package com.partnerd.web.dto.clubDTO;
+
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@AllArgsConstructor
+public class ClubDetailCollabDTO {
+    private String title;
+    private String description;
+    private Date openDate; // 추후리팩토링
+}

--- a/src/main/java/com/partnerd/web/dto/clubDTO/ClubDetailMemberDTO.java
+++ b/src/main/java/com/partnerd/web/dto/clubDTO/ClubDetailMemberDTO.java
@@ -1,0 +1,13 @@
+package com.partnerd.web.dto.clubDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ClubDetailMemberDTO {
+    private String name;
+    private String role; // "LEADER", "MEMBER"
+    private String interest; // 멤버 관심 분야 (@PM, @Developer 등)
+    private String club; // 클럽 이름
+}

--- a/src/main/java/com/partnerd/web/dto/clubDTO/ClubDetailResponseDTO.java
+++ b/src/main/java/com/partnerd/web/dto/clubDTO/ClubDetailResponseDTO.java
@@ -1,0 +1,24 @@
+package com.partnerd.web.dto.clubDTO;
+
+import com.partnerd.web.dto.contactMethodDTO.ContactMethodDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ClubDetailResponseDTO {
+    private Long clubId;
+    private String name;
+    private String category;
+    private String intro;
+    private String profileImage;  //프로필 키네임
+    private String bannerImage;   // 배너 키네임
+    private List<ContactMethodDTO> contactMethod;
+    private ClubActivityDTO activity;
+    private List<ClubDetailMemberDTO> leaderMembers;
+    private List<ClubDetailMemberDTO> generalMembers;
+    private List<ClubDetailCollabDTO> collabPosts; //  최대 5개
+    private boolean isLeader;
+}

--- a/src/main/java/com/partnerd/web/dto/contactMethodDTO/ContactMethodDTO.java
+++ b/src/main/java/com/partnerd/web/dto/contactMethodDTO/ContactMethodDTO.java
@@ -23,4 +23,9 @@ public class ContactMethodDTO {
     public static ContactMethodDTO toContactMethodDTO(ContactMethod contactMethod) {
         return new ContactMethodDTO(contactMethod);
     }
+
+    public ContactMethodDTO(String contactType, String contactUrl) {
+        this.contactType = contactType;
+        this.contactUrl = contactUrl;
+    }
 }


### PR DESCRIPTION
# PR 템플릿

## #️⃣ 연관된 이슈

> ex) #70 



## 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?



## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
<img width="844" alt="image" src="https://github.com/user-attachments/assets/5015799e-7fd2-4896-9897-b816d89ebd51" />

파트너드 상세조회 (팀페이지) API를 구현했습니다.
운영진멤버, 클럽멤버(최대5명) 반환하도록 하였고, 
요청한 멤버가 요청 동아리의 운영진이라면 leader : true를 반환하였습니다. ( 프론트분이 이 값을 보고 다른 페이지를 띄우도록)


## 💬피드백을 받고 싶은 부분 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?




### PR 특이 사항

> 어떤 부분에 리뷰어가 집중하면 좋을까요?
