### PR TITLE
[FIX]API path 구분을 위해 변경 및 kafka consumer json 역직렬화 설정 추가

### DIFF
--- a/src/main/java/com/partnerd/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/com/partnerd/config/kafka/KafkaConsumerConfig.java
@@ -1,5 +1,6 @@
 package com.partnerd.config.kafka;
 
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -23,7 +24,7 @@ public class KafkaConsumerConfig {
         props.put(ConsumerConfig.GROUP_ID_CONFIG, "chat-group-id");
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class); // ✅ JSON 역직렬화 추가
         return new DefaultKafkaConsumerFactory<>(props);
     }
 

--- a/src/main/java/com/partnerd/service/kafkaService/KafkaProducer.java
+++ b/src/main/java/com/partnerd/service/kafkaService/KafkaProducer.java
@@ -16,8 +16,9 @@ public class KafkaProducer {
     private final KafkaTemplate<String, Message> kafkaTemplate;
 
     public void sendMessage(ChatDTO chatDTO) {
+
         // 메시지 객체 생성
-        Message message = Message.builder()
+       Message message = Message.builder()
                 .id(UUID.randomUUID().toString())  // 메시지 ID 자동 생성
                 .chatRoomId(chatDTO.getChatRoomId())
                 .contentType("text")  // 기본 텍스트 타입
@@ -29,7 +30,14 @@ public class KafkaProducer {
                 .readCount(0) // 초기 읽음 카운트 0
                 .build();
 
-        kafkaTemplate.send("chat",  String.valueOf(chatDTO.getChatRoomId()), message);
+       /**
+        *  roomId를 Key로 설정하면 Kafka가 자동으로 동일한 roomId 메시지를 같은 파티션으로 보냄
+        *
+        * ✔ 파티셔닝 전략
+        * Kafka 기본 파티셔너(DefaultPartitioner)가 key.hash() % partition 개수 로 파티션을 배정함
+        * */
+
+        kafkaTemplate.send("chat-topic",  String.valueOf(chatDTO.getChatRoomId()), message);
     }
 
 

--- a/src/main/java/com/partnerd/web/controller/chatController/ChatController.java
+++ b/src/main/java/com/partnerd/web/controller/chatController/ChatController.java
@@ -1,5 +1,6 @@
 package com.partnerd.web.controller.chatController;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.partnerd.service.kafkaService.KafkaProducer;
 import com.partnerd.web.dto.chatDTO.ChatDTO;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/partnerd/web/controller/chatController/ChatRoomRestController.java
+++ b/src/main/java/com/partnerd/web/controller/chatController/ChatRoomRestController.java
@@ -56,7 +56,7 @@ public class ChatRoomRestController {
     }
 
     // 콜라보 요청 시 chatRoom 생성
-    @PostMapping("/{collabAskId}")
+    @PostMapping("/collab/{collabAskId}")
     @Operation(summary = "콜라보 요청 채팅방 생성 API", description = "콜라보 요청 채팅방을 생성할 수 있는 API입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
@@ -73,7 +73,7 @@ public class ChatRoomRestController {
     }
 
     // 컨택트 시 chatRoom 생성
-    @PostMapping("/{nickname}")
+    @PostMapping("/private/{nickname}")
     @Operation(summary = "컨택트 채팅방 생성 API", description = "컨택트 채팅방을 생성할 수 있는 API입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),


### PR DESCRIPTION
# PR 템플릿

## #️⃣ 연관된 이슈

> #93 



## 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?



## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

API 경로를 {param} 값으로 구분 했더니 같은 url로 인식하는 문제가 생겨 수정합니다.

## 💬피드백을 받고 싶은 부분 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?




### PR 특이 사항

> 어떤 부분에 리뷰어가 집중하면 좋을까요?
