### PR TITLE
Feat: 닉네임멤버조회 API 구현

### DIFF
--- a/src/main/java/com/partnerd/repository/memberRepository/MemberRepository.java
+++ b/src/main/java/com/partnerd/repository/memberRepository/MemberRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>,MemberRepositoryCustom {
 
     /**
      * socialId로 사용자 정보를 조회

--- a/src/main/java/com/partnerd/repository/memberRepository/MemberRepositoryCustom.java
+++ b/src/main/java/com/partnerd/repository/memberRepository/MemberRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.partnerd.repository.memberRepository;
+
+import com.partnerd.domain.Member;
+
+import java.util.List;
+
+public interface MemberRepositoryCustom {
+    List<Member> findByNicknameContaining(String nickname);
+}

--- a/src/main/java/com/partnerd/repository/memberRepository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/partnerd/repository/memberRepository/MemberRepositoryCustomImpl.java
@@ -1,0 +1,25 @@
+package com.partnerd.repository.memberRepository;
+
+import com.partnerd.domain.Member;
+import com.partnerd.domain.QMember;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Member> findByNicknameContaining(String nickname) {
+        QMember member = QMember.member;
+
+        return queryFactory
+                .selectFrom(member)
+                .where(member.nickname.contains(nickname)) // LIKE '%닉네임%'
+                .orderBy(member.nickname.asc()) // 닉네임 오름차순 정렬
+                .fetch();
+    }
+}

--- a/src/main/java/com/partnerd/service/clubService/ClubService.java
+++ b/src/main/java/com/partnerd/service/clubService/ClubService.java
@@ -2,6 +2,7 @@ package com.partnerd.service.clubService;
 
 import com.partnerd.domain.Club;
 import com.partnerd.web.dto.clubDTO.*;
+import com.partnerd.web.dto.memberDTO.MemberNickNameSearchDTO;
 
 import java.util.List;
 
@@ -15,6 +16,9 @@ public interface ClubService {
 
     // 파트너드 상세조회 (팀페이지)
     ClubDetailResponseDTO findClubDetails(Long clubId, Long memberId);
+
+    //멤버닉네임조회 (파트너드 등록시 필요)
+    List<MemberNickNameSearchDTO> searchMembersByNickname(String nickname);
 
     // 파트너드 목록 조회(마이페이지)
     List<Club> getClubsByRole(Long memberId);

--- a/src/main/java/com/partnerd/service/clubService/impl/ClubServiceImpl.java
+++ b/src/main/java/com/partnerd/service/clubService/impl/ClubServiceImpl.java
@@ -17,11 +17,13 @@ import com.partnerd.repository.clubRepository.ClubRepository;
 import com.partnerd.repository.memberRepository.MemberRepository;
 import com.partnerd.service.clubService.ClubService;
 import com.partnerd.web.dto.clubDTO.*;
+import com.partnerd.web.dto.memberDTO.MemberNickNameSearchDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -200,9 +202,24 @@ public class ClubServiceImpl implements ClubService {
         return clubRepository.findClubDetails(clubId, memberId);
     }
 
+    //멤버 전체조회 (파트너드 등록시 필요)
+    @Override
+    public List<MemberNickNameSearchDTO> searchMembersByNickname(String nickname) {
+        List<Member> members = memberRepository.findByNicknameContaining(nickname);
+
+        if (members.isEmpty()) {
+            throw new ClubHandler(ErrorStatus.MEMBER_NOT_FOUND);
+        }
+
+        return members.stream()
+                .map(member -> new MemberNickNameSearchDTO(member.getNickname(), member.getProfile_url()))
+                .collect(Collectors.toList());
+    }
+
     // 파트너드 목록 조회(마이페이지)
     @Override
     public List<Club> getClubsByRole(Long memberId) {
         return clubMemberRepository.findClubsByRole(memberId, List.of(ClubMemberRole.LEADER, ClubMemberRole.OFFICER));
     }
+
 }

--- a/src/main/java/com/partnerd/web/controller/clubController/ClubRestController.java
+++ b/src/main/java/com/partnerd/web/controller/clubController/ClubRestController.java
@@ -7,6 +7,7 @@ import com.partnerd.converter.clubConverter.ClubConverter;
 import com.partnerd.domain.Club;
 import com.partnerd.service.clubService.ClubService;
 import com.partnerd.web.dto.clubDTO.*;
+import com.partnerd.web.dto.memberDTO.MemberNickNameSearchDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -167,5 +168,28 @@ public class ClubRestController {
         List<Club> clubs = clubService.getClubsByRole(memberId);
 
        return ApiResponse.onSuccess(ClubConverter.clubPreviewListDTO(clubs));
+    }
+
+    @GetMapping("/register/members")
+    @Operation(summary = "닉네임 검색 API", description = "입력한 닉네임이 포함된 멤버 목록을 반환하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 조회되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "일치하는 멤버가 없습니다.")
+    })
+    @Parameters({
+            @Parameter(name = "nickname", description = "검색할 닉네임", example = "홍길동")
+    })
+    public ApiResponse<List<MemberNickNameSearchDTO>> searchMembersByNickname(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestParam(name = "nickname") String nickname
+    ) {
+        // 1. JWT 토큰 추출 (로그인된 사용자만 접근 가능)
+        String token = authorizationHeader.replace("Bearer ", "");
+        Long memberId = Long.valueOf(jwtTokenProvider.getClaims(token).getSubject());
+
+        // 2. 서비스 호출
+        List<MemberNickNameSearchDTO> members = clubService.searchMembersByNickname(nickname);
+        return ApiResponse.of(SuccessStatus._OK, members);
     }
 }

--- a/src/main/java/com/partnerd/web/dto/memberDTO/MemberNickNameSearchDTO.java
+++ b/src/main/java/com/partnerd/web/dto/memberDTO/MemberNickNameSearchDTO.java
@@ -1,0 +1,14 @@
+package com.partnerd.web.dto.memberDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberNickNameSearchDTO {
+    private String nickname;
+    private String profileKeyName;
+
+}
+
+


### PR DESCRIPTION
memberRepositoryCustom추가 ,customImpl추가하였고 club에서만 사용하는 api라서 controller,service는 club에서 구현했습니다


# PR 템플릿

## #️⃣ 연관된 이슈

> ex) #196 



## 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?



## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

파트너드 등록시 부리더 권한 부여를 위해 
닉네임을 통해 멤버를 조회하는 API입니다.
<img width="663" alt="image" src="https://github.com/user-attachments/assets/4c94fe79-2127-4c8d-9956-39615fb8d77d" />

![image](https://github.com/user-attachments/assets/4db2c497-33c5-4dd1-bc2b-c0655acb1ed5)




## 💬피드백을 받고 싶은 부분 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
memberRepositoryCustom과 memberRepositoryCustomImpl을 추가했습니다!! 





### PR 특이 사항

> 어떤 부분에 리뷰어가 집중하면 좋을까요?

memberRepositoryCustom과 memberRepositoryCustomImpl을 추가했습니다!! 

그리고 이 API가 파트너드등록시에만 쓰일것같아서

다른분들 코드를 건드리는 것보단 제가 다루는 코드에서 만드는게 나을 것같아

clubController,service에 구현을 했는데,

이부분 봐주시면 감사하겠습니다!


