### PR TITLE
[FIX] config 역직렬화 설정 인스턴스에서 프로퍼티 방식으로 변경

### DIFF
--- a/src/main/java/com/partnerd/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/com/partnerd/config/kafka/KafkaConsumerConfig.java
@@ -29,19 +29,18 @@ public class KafkaConsumerConfig {
 
     @Bean
     public ConsumerFactory<String, Message> consumerFactory() {
-        JsonDeserializer<Message> deserializer = new JsonDeserializer<>(Message.class);
-        deserializer.setRemoveTypeHeaders(false); // ✅ Kafka 헤더에서 타입 정보 제거 안 함
-        deserializer.addTrustedPackages("*"); // ✅ 모든 패키지 허용
-        deserializer.setUseTypeMapperForKey(false); // ✅ Key는 타입 매핑 필요 없음
-
         Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVER);
         props.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        // JsonDeserializer 관련 프로퍼티로 설정 (프로퍼티 방식)
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, Message.class.getName());
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);  // 헤더에서 타입 정보를 사용하지 않음
 
-        return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), deserializer);
-
+        return new DefaultKafkaConsumerFactory<>(props);
     }
 
     @Bean


### PR DESCRIPTION
# PR 템플릿

## #️⃣ 연관된 이슈

> #215



## 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?



## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

계속해서 중복 설정 오류가 남. DefaultKafkaConsumerFactory는 내부적으로 props 맵의 값을 사용해 deserializer의 configure 메서드를 호출하기 때문에 인스턴스를 또 설정해주면 오류가 나서 다시 프로퍼티 방식으로 변경


## 💬피드백을 받고 싶은 부분 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?




### PR 특이 사항

> 어떤 부분에 리뷰어가 집중하면 좋을까요?
