### PR TITLE
[REFACTOR] 콜라보 글 조회 성능 개선

### DIFF
--- a/src/main/java/com/partnerd/converter/collabPostConverter/CollabPostConverter.java
+++ b/src/main/java/com/partnerd/converter/collabPostConverter/CollabPostConverter.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 public class CollabPostConverter {
 
 
-    public static CollabPostResponseDTO.CollabPostPreviewDTO collabPostPreviewDTO(CollabPost collabPost) {
+/*    public static CollabPostResponseDTO.CollabPostPreviewDTO collabPostPreviewDTO(CollabPost collabPost) {
 
         List<CategoryDTO> categoryDTOS =  collabPost.getCollabPostCategoryList().stream()
                 .map(collabPostCategory -> {
@@ -43,14 +43,12 @@ public class CollabPostConverter {
                 .mainImgKeyname(mainImgKeyname)
                 .categoryDTOList(categoryDTOS)
                 .build();
-    }
+    }*/
 
-    public static CollabPostResponseDTO.CollabPostPreviewListDTO collabPostPreviewListDTO(Page<CollabPost> collabPostPage) {
-        List<CollabPostResponseDTO.CollabPostPreviewDTO> collabPostPreviewDTOList =
-                    collabPostPage.stream().map(CollabPostConverter::collabPostPreviewDTO).collect(Collectors.toList());
+    public static CollabPostResponseDTO.CollabPostPreviewListDTO collabPostPreviewListDTO(Page<CollabPostResponseDTO.CollabPostPreviewDTO> collabPostPage) {
 
         return CollabPostResponseDTO.CollabPostPreviewListDTO.builder()
-                .collabPostPreviewDTOLList(collabPostPreviewDTOList)
+                .collabPostPreviewDTOList(collabPostPage.getContent())
                 .listSize(collabPostPage.getSize())
                 .totalPage(collabPostPage.getTotalPages())
                 .totalElements(collabPostPage.getTotalElements())

--- a/src/main/java/com/partnerd/domain/mapping/ClubMember.java
+++ b/src/main/java/com/partnerd/domain/mapping/ClubMember.java
@@ -60,7 +60,7 @@ public class ClubMember extends BaseEntity {
     private Set<CollabAsk> receivedCollabAsks = new HashSet<>();
 
 
-
-
-
+    public ClubMember(Long randomClubMemberId) {
+        super();
+    }
 }

--- a/src/main/java/com/partnerd/repository/collabPostRepository/collabPost/CollabPostRepository.java
+++ b/src/main/java/com/partnerd/repository/collabPostRepository/collabPost/CollabPostRepository.java
@@ -1,11 +1,13 @@
 package com.partnerd.repository.collabPostRepository.collabPost;
 
 import com.partnerd.domain.CollabPost;
+import com.partnerd.web.dto.collabDTO.response.CollabPostResponseDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,7 +15,6 @@ public interface CollabPostRepository extends JpaRepository<CollabPost, Long>, C
 
     @Query("SELECT cp FROM CollabPost cp LEFT JOIN FETCH cp.collabInquiryList ci WHERE cp.id = :id")
     Optional<CollabPost> findByIdWithInquiry(@Param("id") Long collabPostId);
-
     List<CollabPost> findTop4ByOrderByCreatedAtDesc();
 
     @Query("SELECT cp FROM CollabPost cp " +

--- a/src/main/java/com/partnerd/repository/collabPostRepository/collabPost/CollabPostRepositoryCustom.java
+++ b/src/main/java/com/partnerd/repository/collabPostRepository/collabPost/CollabPostRepositoryCustom.java
@@ -1,26 +1,26 @@
 package com.partnerd.repository.collabPostRepository.collabPost;
 
 import com.partnerd.domain.CollabPost;
+import com.partnerd.web.dto.collabDTO.request.CollabPostRequestDTO;
 import com.partnerd.web.dto.collabDTO.response.CollabPostResponseDTO;
 import com.partnerd.web.dto.homeDTO.response.HomeCollabPostDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.List;
-
 import java.util.Optional;
 
 public interface CollabPostRepositoryCustom {
     Page<CollabPostResponseDTO.CollabPostPreviewDTO> findAllWithCategories(Pageable pageable);
-    CollabPostResponseDTO.PagingResultDTO<CollabPostResponseDTO.CollabPostPreviewDTO> findAllWithNoOffset(LocalDateTime lastCreatedAt, Date lastEndDate, String sortBy, int size);
 
-    /*    Page<CollabPost> findAllByCategories(Pageable pageable, List<Long> categories);*/
+    // No offset Paging
+    CollabPostResponseDTO.PagingResultDTO<CollabPostResponseDTO.CollabPostPreviewDTO> findAllWithNoOffset(CollabPostRequestDTO.RequestNoOffsetPagingDTO requestNoOffsetPagingDTO);
+
+    Page<CollabPost> findAllByCategories(Pageable pageable, List<Long> categories);
+
     CollabPost findCollabPostDetails(Long collabPostId);
-    Optional<CollabPost> findByIdWithMember(Long collabPostId);
 
+    Optional<CollabPost> findByIdWithMember(Long collabPostId);
     // 마이페이지 - 내가 쓴 콜라보레이션 모아보기
     List<CollabPost> findCollabPostsByMemberId(Long memberId);
 

--- a/src/main/java/com/partnerd/repository/collabPostRepository/collabPost/CollabPostRepositoryCustom.java
+++ b/src/main/java/com/partnerd/repository/collabPostRepository/collabPost/CollabPostRepositoryCustom.java
@@ -7,13 +7,17 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.List;
 
 import java.util.Optional;
 
 public interface CollabPostRepositoryCustom {
-    Page<CollabPost> findAllWithCategories(Pageable pageable);
-    Page<CollabPost> findAllByCategories(Pageable pageable, List<Long> categories);
+    Page<CollabPostResponseDTO.CollabPostPreviewDTO> findAllWithCategories(Pageable pageable);
+    CollabPostResponseDTO.PagingResultDTO<CollabPostResponseDTO.CollabPostPreviewDTO> findAllWithNoOffset(LocalDateTime lastCreatedAt, Date lastEndDate, String sortBy, int size);
+
+    /*    Page<CollabPost> findAllByCategories(Pageable pageable, List<Long> categories);*/
     CollabPost findCollabPostDetails(Long collabPostId);
     Optional<CollabPost> findByIdWithMember(Long collabPostId);
 

--- a/src/main/java/com/partnerd/repository/collabPostRepository/collabPost/CollabPostRepositoryCustomImpl.java
+++ b/src/main/java/com/partnerd/repository/collabPostRepository/collabPost/CollabPostRepositoryCustomImpl.java
@@ -1,13 +1,17 @@
 package com.partnerd.repository.collabPostRepository.collabPost;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.partnerd.domain.*;
 import com.partnerd.domain.enums.ImageType;
 import com.partnerd.domain.mapping.QClubMember;
 import com.partnerd.domain.mapping.QCollabPostCategory;
 import com.partnerd.web.dto.categoryDTO.CategoryDTO;
 import com.partnerd.web.dto.categoryDTO.CollabPostCategoryDTO;
+import com.partnerd.web.dto.collabDTO.request.CollabPostRequestDTO;
 import com.partnerd.web.dto.collabDTO.response.CollabPostResponseDTO;
 import com.partnerd.web.dto.homeDTO.response.HomeCollabPostDTO;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.SubQueryExpression;
@@ -16,9 +20,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -98,46 +100,24 @@ public class CollabPostRepositoryCustomImpl implements CollabPostRepositoryCusto
         PagingResultDTO pagingResultDTO = applySortingAndPaging(query, pageable);
         List<CollabPostResponseDTO.CollabPostPreviewDTO> collabPosts = pagingResultDTO.getResults();
 
-/*        // 각 collabPost의 ID 리스트 추출
-        List<Long> postIds = collabPosts.stream().map(CollabPostResponseDTO.CollabPostPreviewDTO::getCollabPostId).collect(Collectors.toList());
-
-        Map<Long, List<CollabPostCategoryDTO>> categoryMap = queryFactory
-                .select(Projections.constructor(
-                        CollabPostCategoryDTO.class,
-                        qCollabPostCategory.collabPost.id,
-                        qCategory.id,
-                        qCategory.name
-                ))
-                .from(qCollabPostCategory)
-                .join(qCategory).on(qCollabPostCategory.category.id.eq(qCategory.id))
-                .where(qCollabPostCategory.collabPost.id.in(postIds))
-                .fetch()
-                .stream()
-                .collect(Collectors.groupingBy(CollabPostCategoryDTO::getCollabPostId));
-        // DTO에 데이터 매핑
-        collabPosts.forEach(post -> {
-            post.setCategoryDTOList(categoryMap.getOrDefault(post.getCollabPostId(), Collections.emptyList()));
-        });*/
+        // 콜라보 글 별로 해당하는 카테고리 DTO 찾기.
+        getCategoryListDTO(collabPosts);
 
         return new PageImpl<>(pagingResultDTO.getResults(), pageable, pagingResultDTO.getTotal());
     }
 
     @Override
-    public CollabPostResponseDTO.PagingResultDTO<CollabPostResponseDTO.CollabPostPreviewDTO> findAllWithNoOffset(LocalDateTime lastCreatedAt, Date lastEndDate, String sortBy, int size) {
+    public CollabPostResponseDTO.PagingResultDTO<CollabPostResponseDTO.CollabPostPreviewDTO> findAllWithNoOffset(CollabPostRequestDTO.RequestNoOffsetPagingDTO requestNoOffsetPagingDTO) {
 
-        // 첫 페이지 요청이면 전체 데이터 개수 조회
-        long totalElements = (lastCreatedAt == null) ? getTotalElements() : -1;
-        OrderSpecifier<?> orderSpecifier;
-        BooleanExpression paginationCondition;
+        int pageNum = requestNoOffsetPagingDTO.getPageNum();
+        Date lastEndDate = requestNoOffsetPagingDTO.getLastEndDate();
+        LocalDateTime lastCreatedAt = requestNoOffsetPagingDTO.getLastCreatedAt();
+        Long lastId = requestNoOffsetPagingDTO.getLastId();
+        int size = requestNoOffsetPagingDTO.getSize();
+        String sortBy = requestNoOffsetPagingDTO.getSortBy();
 
-        if ("endDate".equalsIgnoreCase(sortBy)) {
-            orderSpecifier = qCollabPost.endDate.asc(); // 마감일순 (오름차순)
-            paginationCondition = (lastEndDate != null) ? qCollabPost.endDate.after(lastEndDate) : Expressions.TRUE;
-        } else {
-            orderSpecifier = qCollabPost.createdAt.desc(); // 최신순 (내림차순)
-            paginationCondition = (lastCreatedAt != null) ? qCollabPost.createdAt.lt(lastCreatedAt) : Expressions.TRUE;
-        }
-
+        OrderSpecifier<?>[] orderSpecifiers = getOrderSpecifier(sortBy);
+        BooleanExpression paginationCondition = getPageCondition(sortBy, lastEndDate, lastCreatedAt, lastId);
 
         List<CollabPostResponseDTO.CollabPostPreviewDTO> collabPosts = queryFactory
                 .select(Projections.constructor(
@@ -154,61 +134,157 @@ public class CollabPostRepositoryCustomImpl implements CollabPostRepositoryCusto
                 ))
                 .from(qCollabPost)
                 .where(paginationCondition) // Keyset Pagination 적용
-                .orderBy(orderSpecifier)
+                .orderBy(orderSpecifiers)
                 .limit(size + 1)  // 마지막 페이지 판별을 위해 `size+1`개 조회
                 .fetch();
-
         // 콜라보 글 별로 해당하는 카테고리 DTO 찾기.
-        List<Long> postIds = collabPosts.stream().map(CollabPostResponseDTO.CollabPostPreviewDTO::getCollabPostId).collect(Collectors.toList());
-
-        Map<Long, List<CollabPostCategoryDTO>> categoryMap = queryFactory.
-                                select(Projections.constructor(
-                                CollabPostCategoryDTO.class,
-                                qCollabPostCategory.collabPost.id,
-                                qCategory.id,
-                                qCategory.name
-                        ))
-                                .from(qCollabPostCategory)
-                                .join(qCategory).on(qCollabPostCategory.category.id.eq(qCategory.id))
-                                .where(qCollabPostCategory.collabPost.id.in(postIds))
-                                .fetch()
-                                .stream()
-                                .collect(Collectors.groupingBy(CollabPostCategoryDTO::getCollabPostId));
-
-        collabPosts.forEach(post -> {
-            post.setCategoryDTOList(categoryMap.getOrDefault(post.getCollabPostId(), Collections.emptyList()));
-        });
-
+        getCategoryListDTO(collabPosts);
         // 마지막 페이지인지 확인
         boolean isLast = collabPosts.size() <= size;
         if (!isLast) {
             collabPosts.remove(collabPosts.size() - 1); // ✅ 다음 페이지 데이터 제거
         }
 
+        InitialFetchDTO initialFetchDTO = pageNum % 10 == 1 ? initialFetchPage(size, sortBy, lastEndDate, lastCreatedAt, lastId) : null;
+
         return CollabPostResponseDTO.PagingResultDTO.<CollabPostResponseDTO.CollabPostPreviewDTO>builder()
                 .data(collabPosts)
                 .listSize(collabPosts.size())
-                .totalElements(totalElements) // ✅ 첫 페이지 요청 시만 totalElements 포함
-                .totalPages((totalElements == -1) ? -1 : (int) Math.ceil((double) totalElements / size)) // totalPages 계산
-                .isFirst(lastCreatedAt == null)
+                .hasMorePages(initialFetchDTO != null ? initialFetchDTO.hasMorePages : false)  // 첫페이지 요청시 10페이지 이상의 데이터가 더 있는지 여부
+                .availablePages(initialFetchDTO != null ? initialFetchDTO.availablePages : -1) // 첫페이지 요청시 몇 페이지를 표시할 수 있는지 확인할 수 있는 최대 페이지 번호
+                .pageReferenceDTOList(initialFetchDTO != null ? initialFetchDTO.getPageReferenceDTOList() : null)
+                .isFirst(pageNum == 1)
                 .isLast(isLast)
                 .build();
     }
 
 
+    private void getCategoryListDTO (List<CollabPostResponseDTO.CollabPostPreviewDTO> collabPosts) {
+        // 각 collabPost의 ID 리스트 추출
+        List<Long> postIds = collabPosts.stream().map(CollabPostResponseDTO.CollabPostPreviewDTO::getCollabPostId).collect(Collectors.toList());
 
-        // ✅ 전체 데이터 개수 조회하는 메서드
-    private long getTotalElements() {
-        return queryFactory
-                .select(qCollabPost.count())
-                .from(qCollabPost)
-                .fetchOne();
+        Map<Long, List<CollabPostCategoryDTO>> categoryMap = queryFactory.
+                select(Projections.constructor(
+                        CollabPostCategoryDTO.class,
+                        qCollabPostCategory.collabPost.id,
+                        qCategory.id,
+                        qCategory.name
+                ))
+                .from(qCollabPostCategory)
+                .join(qCategory).on(qCollabPostCategory.category.id.eq(qCategory.id))
+                .where(qCollabPostCategory.collabPost.id.in(postIds))
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(CollabPostCategoryDTO::getCollabPostId));
+
+        collabPosts.forEach(post -> {
+            post.setCategoryDTOList(categoryMap.getOrDefault(post.getCollabPostId(), Collections.emptyList()));
+        });
+
+    }
+    // 정렬기준에 따른 동적 정렬
+    private OrderSpecifier<?>[] getOrderSpecifier(String sortBy) {
+
+        if ("endDate".equalsIgnoreCase(sortBy)) {
+            return new OrderSpecifier<?>[]{
+                    new OrderSpecifier<>(Order.ASC, qCollabPost.endDate),
+                    new OrderSpecifier<>(Order.ASC, qCollabPost.id)
+            };
+        } else {
+            return new OrderSpecifier<?>[]{
+                    new OrderSpecifier<>(Order.DESC, qCollabPost.createdAt),
+                    new OrderSpecifier<>(Order.DESC, qCollabPost.id)
+            };
+        }
     }
 
+    // 마지막 글에 대한 key Pagination
+    private  BooleanExpression getPageCondition (String sortBy, Date lastEndDate, LocalDateTime lastCreatedAt, Long lastId) {
 
- /*   @Override
+        if ("endDate".equalsIgnoreCase(sortBy) && lastEndDate != null && lastId != null) {
+            return qCollabPost.id.gt(lastId)  // 먼저 `id` 기준으로 중복 데이터 필터링
+                    .and(qCollabPost.endDate.goe(lastEndDate)); // 그다음 `endDate` 조건 적용
+
+        } else if (lastCreatedAt != null && lastId != null) {
+            return qCollabPost.id.gt(lastId)  // 최신순일 경우도 `id` 먼저 필터링
+                    .and(qCollabPost.createdAt.loe(lastCreatedAt));
+        }
+        return Expressions.TRUE;
+    }
+
+    // 최대 10 페이지까지의 개수 조회 메서드
+    private InitialFetchDTO initialFetchPage(int size, String sortBy, Date lastEndDate, LocalDateTime lastCreatedAt, Long lastId) {
+
+        int maxInitialPages = 10; // 처음에 표시할 최대 페이지 개수
+        int initialFetchSize = size * maxInitialPages; // 10페이지까지 확인할 개수
+
+        OrderSpecifier<?>[] orderSpecifiers = getOrderSpecifier(sortBy);
+        BooleanExpression paginationCondition = getPageCondition(sortBy, lastEndDate, lastCreatedAt, lastId);
+
+        // 10페이지까지 데이터가 있는지 확인
+        List<Tuple> pageCheck = queryFactory
+                .select(qCollabPost.id, qCollabPost.endDate, qCollabPost.createdAt) // 전체 개수를 구하지 않고 10페이지까지 ID만 조회
+                .from(qCollabPost)
+                .where(paginationCondition)
+                .orderBy(orderSpecifiers) // 정렬 방식 적용
+                .limit(initialFetchSize + 1) // 10페이지 + 1개 데이터만 확인
+                .fetch();
+
+        boolean hasMorePages = pageCheck.size() > initialFetchSize; // 10페이지 이상 존재 여부 확인
+        List<PageReferenceDTO> pageReferences = new ArrayList<>();
+
+        for (int i = 0; i < Math.min(pageCheck.size(), initialFetchSize); i += size) {
+            Tuple lastTuple = pageCheck.get(i);
+
+            // `sortBy` 값에 따라 적절한 필드 설정
+            PageReferenceDTO pageReference;
+            if ("endDate".equalsIgnoreCase(sortBy)) {
+                pageReference = PageReferenceDTO.builder()
+                        .lastId(lastTuple.get(qCollabPost.id))
+                        .lastEndDate(lastTuple.get(qCollabPost.endDate)) // endDate 정렬 시 설정
+                        .build();
+            } else {
+                pageReference = PageReferenceDTO.builder()
+                        .lastId(lastTuple.get(qCollabPost.id))
+                        .lastCreatedAt(lastTuple.get(qCollabPost.createdAt)) // createdAt 정렬 시 설정
+                        .build();
+            }
+
+            pageReferences.add(pageReference);
+        }
+        // 현재 표시할 수 있는 페이지 수 (실제 데이터 개수 기준)
+        int availablePages = (int) Math.ceil((double) Math.min(pageCheck.size(),initialFetchSize) / size);
+
+        return InitialFetchDTO.builder()
+                .hasMorePages(hasMorePages)
+                .availablePages(availablePages)
+                .pageReferenceDTOList(pageReferences)
+                .build();
+    }
+
+    @Getter
+    @Builder
+    private static class InitialFetchDTO {
+        private boolean hasMorePages;
+        private int availablePages;
+        private List<PageReferenceDTO> pageReferenceDTOList;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL) // null 값은 JSON 응답에서 제외
+    public static class PageReferenceDTO {
+        private Long lastId;
+        private Date lastEndDate; // 마감일 기준 정렬 시 사용
+        private LocalDateTime lastCreatedAt; // 최신순 정렬 시 사용
+
+    }
+
+   @Override
     public Page<CollabPost> findAllByCategories(Pageable pageable, List<Long> categories) {
-
+    /*
         JPAQuery<CollabPost> query = queryFactory
                 .selectFrom(qCollabPost)
                 .leftJoin(qCollabPost.collabPostCategoryList, qCollabPostCategory).fetchJoin()
@@ -219,8 +295,10 @@ public class CollabPostRepositoryCustomImpl implements CollabPostRepositoryCusto
         PagingResultDTO pagingResultDTO = applySortingAndPaging(query, pageable);
 
         return new PageImpl<>(pagingResultDTO.getResults(), pageable, pagingResultDTO.getTotal());
-    }
-*/
+    */
+       return null;
+   }
+
 
     @Override
     public CollabPost findCollabPostDetails(Long collabPostId) {

--- a/src/main/java/com/partnerd/repository/collabPostRepository/collabPost/CollabPostRepositoryCustomImpl.java
+++ b/src/main/java/com/partnerd/repository/collabPostRepository/collabPost/CollabPostRepositoryCustomImpl.java
@@ -4,8 +4,16 @@ import com.partnerd.domain.*;
 import com.partnerd.domain.enums.ImageType;
 import com.partnerd.domain.mapping.QClubMember;
 import com.partnerd.domain.mapping.QCollabPostCategory;
+import com.partnerd.web.dto.categoryDTO.CategoryDTO;
+import com.partnerd.web.dto.categoryDTO.CollabPostCategoryDTO;
+import com.partnerd.web.dto.collabDTO.response.CollabPostResponseDTO;
 import com.partnerd.web.dto.homeDTO.response.HomeCollabPostDTO;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.SubQueryExpression;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.Builder;
@@ -17,8 +25,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -37,7 +46,7 @@ public class CollabPostRepositoryCustomImpl implements CollabPostRepositoryCusto
     private final QCollabPostImg qCollabPostImg = QCollabPostImg.collabPostImg;
 
 
-    private PagingResultDTO applySortingAndPaging(JPAQuery<CollabPost> query, Pageable pageable) {
+    private PagingResultDTO applySortingAndPaging(JPAQuery<CollabPostResponseDTO.CollabPostPreviewDTO> query, Pageable pageable) {
         Sort sort = pageable.getSort();
         for (Sort.Order order : sort) {
             String property = order.getProperty();
@@ -52,7 +61,7 @@ public class CollabPostRepositoryCustomImpl implements CollabPostRepositoryCusto
                 .from(qCollabPost)
                 .fetchOne();
 
-        List<CollabPost> results = query
+        List<CollabPostResponseDTO.CollabPostPreviewDTO> results = query
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -65,23 +74,139 @@ public class CollabPostRepositoryCustomImpl implements CollabPostRepositoryCusto
     }
 
     @Override
-    public Page<CollabPost> findAllWithCategories(Pageable pageable) {
-        JPAQuery<CollabPost> query = queryFactory
-                .selectFrom(qCollabPost)
-                .leftJoin(qCollabPost.collabPostCategoryList, qCollabPostCategory)
-                .fetchJoin()
-                .leftJoin(qCollabPostCategory.category, qCategory) // Category도 즉시 로딩
-                .fetchJoin()
-                .leftJoin(qCollabPost.collabPostImgList, qCollabPostImg)
-                .fetchJoin();
+    public Page<CollabPostResponseDTO.CollabPostPreviewDTO> findAllWithCategories(Pageable pageable) {
 
-       PagingResultDTO pagingResultDTO = applySortingAndPaging(query, pageable);
+        // 서브쿼리 활용하여 `mainImgKeyname` 가져오기
+        QCollabPostImg subQCollabPostImg = new QCollabPostImg("subQCollabPostImg");
+        SubQueryExpression<String> mainImgSubQuery = JPAExpressions
+                .select(subQCollabPostImg.keyName)
+                .from(subQCollabPostImg)
+                .where(subQCollabPostImg.collabPost.id.eq(qCollabPost.id)
+                        .and(subQCollabPostImg.imageType.eq(ImageType.MAIN)))
+                .limit(1);
+
+        JPAQuery<CollabPostResponseDTO.CollabPostPreviewDTO> query = queryFactory
+                .select(Projections.constructor(
+                        CollabPostResponseDTO.CollabPostPreviewDTO.class,
+                        qCollabPost.id,
+                        qCollabPost.title,
+                        qCollabPost.startDate,
+                        qCollabPost.endDate,
+                        mainImgSubQuery
+                )).from(qCollabPost);
+
+        PagingResultDTO pagingResultDTO = applySortingAndPaging(query, pageable);
+        List<CollabPostResponseDTO.CollabPostPreviewDTO> collabPosts = pagingResultDTO.getResults();
+
+/*        // 각 collabPost의 ID 리스트 추출
+        List<Long> postIds = collabPosts.stream().map(CollabPostResponseDTO.CollabPostPreviewDTO::getCollabPostId).collect(Collectors.toList());
+
+        Map<Long, List<CollabPostCategoryDTO>> categoryMap = queryFactory
+                .select(Projections.constructor(
+                        CollabPostCategoryDTO.class,
+                        qCollabPostCategory.collabPost.id,
+                        qCategory.id,
+                        qCategory.name
+                ))
+                .from(qCollabPostCategory)
+                .join(qCategory).on(qCollabPostCategory.category.id.eq(qCategory.id))
+                .where(qCollabPostCategory.collabPost.id.in(postIds))
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(CollabPostCategoryDTO::getCollabPostId));
+        // DTO에 데이터 매핑
+        collabPosts.forEach(post -> {
+            post.setCategoryDTOList(categoryMap.getOrDefault(post.getCollabPostId(), Collections.emptyList()));
+        });*/
 
         return new PageImpl<>(pagingResultDTO.getResults(), pageable, pagingResultDTO.getTotal());
     }
 
-
     @Override
+    public CollabPostResponseDTO.PagingResultDTO<CollabPostResponseDTO.CollabPostPreviewDTO> findAllWithNoOffset(LocalDateTime lastCreatedAt, Date lastEndDate, String sortBy, int size) {
+
+        // 첫 페이지 요청이면 전체 데이터 개수 조회
+        long totalElements = (lastCreatedAt == null) ? getTotalElements() : -1;
+        OrderSpecifier<?> orderSpecifier;
+        BooleanExpression paginationCondition;
+
+        if ("endDate".equalsIgnoreCase(sortBy)) {
+            orderSpecifier = qCollabPost.endDate.asc(); // 마감일순 (오름차순)
+            paginationCondition = (lastEndDate != null) ? qCollabPost.endDate.after(lastEndDate) : Expressions.TRUE;
+        } else {
+            orderSpecifier = qCollabPost.createdAt.desc(); // 최신순 (내림차순)
+            paginationCondition = (lastCreatedAt != null) ? qCollabPost.createdAt.lt(lastCreatedAt) : Expressions.TRUE;
+        }
+
+
+        List<CollabPostResponseDTO.CollabPostPreviewDTO> collabPosts = queryFactory
+                .select(Projections.constructor(
+                        CollabPostResponseDTO.CollabPostPreviewDTO.class,
+                        qCollabPost.id,
+                        qCollabPost.title,
+                        qCollabPost.startDate,
+                        qCollabPost.endDate,
+                        JPAExpressions.select(qCollabPostImg.keyName)
+                                .from(qCollabPostImg)
+                                .where(qCollabPostImg.collabPost.id.eq(qCollabPost.id)
+                                        .and(qCollabPostImg.imageType.eq(ImageType.MAIN)))
+                                .limit(1)
+                ))
+                .from(qCollabPost)
+                .where(paginationCondition) // Keyset Pagination 적용
+                .orderBy(orderSpecifier)
+                .limit(size + 1)  // 마지막 페이지 판별을 위해 `size+1`개 조회
+                .fetch();
+
+        // 콜라보 글 별로 해당하는 카테고리 DTO 찾기.
+        List<Long> postIds = collabPosts.stream().map(CollabPostResponseDTO.CollabPostPreviewDTO::getCollabPostId).collect(Collectors.toList());
+
+        Map<Long, List<CollabPostCategoryDTO>> categoryMap = queryFactory.
+                                select(Projections.constructor(
+                                CollabPostCategoryDTO.class,
+                                qCollabPostCategory.collabPost.id,
+                                qCategory.id,
+                                qCategory.name
+                        ))
+                                .from(qCollabPostCategory)
+                                .join(qCategory).on(qCollabPostCategory.category.id.eq(qCategory.id))
+                                .where(qCollabPostCategory.collabPost.id.in(postIds))
+                                .fetch()
+                                .stream()
+                                .collect(Collectors.groupingBy(CollabPostCategoryDTO::getCollabPostId));
+
+        collabPosts.forEach(post -> {
+            post.setCategoryDTOList(categoryMap.getOrDefault(post.getCollabPostId(), Collections.emptyList()));
+        });
+
+        // 마지막 페이지인지 확인
+        boolean isLast = collabPosts.size() <= size;
+        if (!isLast) {
+            collabPosts.remove(collabPosts.size() - 1); // ✅ 다음 페이지 데이터 제거
+        }
+
+        return CollabPostResponseDTO.PagingResultDTO.<CollabPostResponseDTO.CollabPostPreviewDTO>builder()
+                .data(collabPosts)
+                .listSize(collabPosts.size())
+                .totalElements(totalElements) // ✅ 첫 페이지 요청 시만 totalElements 포함
+                .totalPages((totalElements == -1) ? -1 : (int) Math.ceil((double) totalElements / size)) // totalPages 계산
+                .isFirst(lastCreatedAt == null)
+                .isLast(isLast)
+                .build();
+    }
+
+
+
+        // ✅ 전체 데이터 개수 조회하는 메서드
+    private long getTotalElements() {
+        return queryFactory
+                .select(qCollabPost.count())
+                .from(qCollabPost)
+                .fetchOne();
+    }
+
+
+ /*   @Override
     public Page<CollabPost> findAllByCategories(Pageable pageable, List<Long> categories) {
 
         JPAQuery<CollabPost> query = queryFactory
@@ -95,7 +220,7 @@ public class CollabPostRepositoryCustomImpl implements CollabPostRepositoryCusto
 
         return new PageImpl<>(pagingResultDTO.getResults(), pageable, pagingResultDTO.getTotal());
     }
-
+*/
 
     @Override
     public CollabPost findCollabPostDetails(Long collabPostId) {
@@ -185,7 +310,7 @@ public class CollabPostRepositoryCustomImpl implements CollabPostRepositoryCusto
     @Getter
     public static class PagingResultDTO {
         private long total;
-        private List<CollabPost> results;
+        private List<CollabPostResponseDTO.CollabPostPreviewDTO> results;
     }
 
 }

--- a/src/main/java/com/partnerd/repository/collabPostRepository/collabPost/bulk/CollabPostBatchRepository.java
+++ b/src/main/java/com/partnerd/repository/collabPostRepository/collabPost/bulk/CollabPostBatchRepository.java
@@ -1,0 +1,48 @@
+package com.partnerd.repository.collabPostRepository.collabPost.bulk;
+
+import com.partnerd.domain.CollabPost;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CollabPostBatchRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    public void insertAll(List<CollabPost> collabPostList) {
+
+        String insertSql ="INSERT INTO collab_post (club_member_id, title, intro, open_date, close_date, start_date, end_date, " +
+                "collab_target, event_mode, description, event_type_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(insertSql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                CollabPost collabPost = collabPostList.get(i);
+                ps.setLong(1, collabPost.getClubMember().getId());
+                ps.setString(2, collabPost.getTitle());
+                ps.setString(3, collabPost.getIntro());
+                ps.setDate(4, (Date) collabPost.getOpenDate());
+                ps.setDate(5, (Date) collabPost.getCloseDate());
+                ps.setDate(6, (Date) collabPost.getStartDate());
+                ps.setDate(7, (Date) collabPost.getEndDate());
+                ps.setString(8, collabPost.getCollabTarget());
+                ps.setInt(9, collabPost.getEventMode());
+                ps.setString(10, collabPost.getDescription());
+                ps.setLong(11, collabPost.getEventType().getId());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return collabPostList.size();
+            }
+        });
+
+    }
+}

--- a/src/main/java/com/partnerd/service/collabPostService/CollabPostQueryService.java
+++ b/src/main/java/com/partnerd/service/collabPostService/CollabPostQueryService.java
@@ -1,14 +1,19 @@
 package com.partnerd.service.collabPostService;
 
 import com.partnerd.domain.CollabPost;
+import com.partnerd.web.dto.collabDTO.response.CollabPostResponseDTO;
 import org.springframework.data.domain.Page;
 
+import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.List;
 
 public interface CollabPostQueryService {
 
-    Page<CollabPost> getCollabPostList(Integer page, String sortBy);
+    CollabPostResponseDTO.PagingResultDTO<CollabPostResponseDTO.CollabPostPreviewDTO> getCollabPostList(LocalDateTime lastCreatedAt, Date lastEndDate, String sortBy, int size);
+/*
     Page<CollabPost> getCollabPostListByCategory(List<Long> categories, Integer page, String sortBy);
+*/
     CollabPost getCollabPost(Long collabPostId);
 
     // 마이페이지 - 내가 쓴 콜라보레이션 모아보기

--- a/src/main/java/com/partnerd/service/collabPostService/CollabPostQueryService.java
+++ b/src/main/java/com/partnerd/service/collabPostService/CollabPostQueryService.java
@@ -1,19 +1,18 @@
 package com.partnerd.service.collabPostService;
 
 import com.partnerd.domain.CollabPost;
+import com.partnerd.web.dto.collabDTO.request.CollabPostRequestDTO;
 import com.partnerd.web.dto.collabDTO.response.CollabPostResponseDTO;
 import org.springframework.data.domain.Page;
 
-import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.List;
 
 public interface CollabPostQueryService {
 
-    CollabPostResponseDTO.PagingResultDTO<CollabPostResponseDTO.CollabPostPreviewDTO> getCollabPostList(LocalDateTime lastCreatedAt, Date lastEndDate, String sortBy, int size);
-/*
+    CollabPostResponseDTO.PagingResultDTO<CollabPostResponseDTO.CollabPostPreviewDTO> getCollabPostList(CollabPostRequestDTO.RequestNoOffsetPagingDTO requestNoOffsetPagingDTO);
+
     Page<CollabPost> getCollabPostListByCategory(List<Long> categories, Integer page, String sortBy);
-*/
+
     CollabPost getCollabPost(Long collabPostId);
 
     // 마이페이지 - 내가 쓴 콜라보레이션 모아보기

--- a/src/main/java/com/partnerd/service/collabPostService/impl/CollabPostQueryServiceImpl.java
+++ b/src/main/java/com/partnerd/service/collabPostService/impl/CollabPostQueryServiceImpl.java
@@ -5,6 +5,7 @@ import com.partnerd.apiPaylaod.exception.handler.CollabPostHandler;
 import com.partnerd.domain.CollabPost;
 import com.partnerd.repository.collabPostRepository.collabPost.CollabPostRepository;
 import com.partnerd.service.collabPostService.CollabPostQueryService;
+import com.partnerd.web.dto.collabDTO.request.CollabPostRequestDTO;
 import com.partnerd.web.dto.collabDTO.response.CollabPostResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -14,8 +15,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.List;
 
 @Service
@@ -25,25 +24,27 @@ public class CollabPostQueryServiceImpl implements CollabPostQueryService {
     private final CollabPostRepository collabPostRepository;
 
 
+    // No offset 페이징 콜라보 글 전체 조회
     @Override
     @Transactional(readOnly=true)
-    public CollabPostResponseDTO.PagingResultDTO<CollabPostResponseDTO.CollabPostPreviewDTO> getCollabPostList(LocalDateTime lastCreatedAt, Date lastEndDate, String sortBy, int size){
+    public CollabPostResponseDTO.PagingResultDTO<CollabPostResponseDTO.CollabPostPreviewDTO> getCollabPostList(CollabPostRequestDTO.RequestNoOffsetPagingDTO requestNoOffsetPagingDTO){
 
         // 페이징 시
         // Pageable pageable = PageRequest.of(page, 9, Sort.by(Sort.Order.desc(sortBy)));
 
         //  No offset 페이징
-        return collabPostRepository.findAllWithNoOffset(lastCreatedAt, lastEndDate, sortBy, size);
+        return collabPostRepository.findAllWithNoOffset(requestNoOffsetPagingDTO);
     }
 
-/*    @Override
+    // 카테고리 별 콜라보 글 조회
+    @Override
     @Transactional(readOnly=true)
     public Page<CollabPost> getCollabPostListByCategory(List<Long> categories, Integer page, String sortBy) {
 
         Pageable pageable = PageRequest.of(page, 9, Sort.by(Sort.Order.desc(sortBy)));
 
         return collabPostRepository.findAllByCategories(pageable, categories);
-    }*/
+    }
 
     @Override
     @Transactional(readOnly=true)

--- a/src/main/java/com/partnerd/service/collabPostService/impl/CollabPostQueryServiceImpl.java
+++ b/src/main/java/com/partnerd/service/collabPostService/impl/CollabPostQueryServiceImpl.java
@@ -5,6 +5,7 @@ import com.partnerd.apiPaylaod.exception.handler.CollabPostHandler;
 import com.partnerd.domain.CollabPost;
 import com.partnerd.repository.collabPostRepository.collabPost.CollabPostRepository;
 import com.partnerd.service.collabPostService.CollabPostQueryService;
+import com.partnerd.web.dto.collabDTO.response.CollabPostResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -13,6 +14,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.List;
 
 @Service
@@ -24,21 +27,23 @@ public class CollabPostQueryServiceImpl implements CollabPostQueryService {
 
     @Override
     @Transactional(readOnly=true)
-    public Page<CollabPost> getCollabPostList(Integer page, String sortBy){
+    public CollabPostResponseDTO.PagingResultDTO<CollabPostResponseDTO.CollabPostPreviewDTO> getCollabPostList(LocalDateTime lastCreatedAt, Date lastEndDate, String sortBy, int size){
 
-        Pageable pageable = PageRequest.of(page, 9, Sort.by(Sort.Order.desc(sortBy)));
+        // 페이징 시
+        // Pageable pageable = PageRequest.of(page, 9, Sort.by(Sort.Order.desc(sortBy)));
 
-        return collabPostRepository.findAllWithCategories(pageable);
+        //  No offset 페이징
+        return collabPostRepository.findAllWithNoOffset(lastCreatedAt, lastEndDate, sortBy, size);
     }
 
-    @Override
+/*    @Override
     @Transactional(readOnly=true)
     public Page<CollabPost> getCollabPostListByCategory(List<Long> categories, Integer page, String sortBy) {
 
         Pageable pageable = PageRequest.of(page, 9, Sort.by(Sort.Order.desc(sortBy)));
 
         return collabPostRepository.findAllByCategories(pageable, categories);
-    }
+    }*/
 
     @Override
     @Transactional(readOnly=true)

--- a/src/main/java/com/partnerd/web/controller/collabPostController/CollabPostRestController.java
+++ b/src/main/java/com/partnerd/web/controller/collabPostController/CollabPostRestController.java
@@ -16,9 +16,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.repository.query.Param;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.List;
 
 @RestController
@@ -97,12 +100,15 @@ public class CollabPostRestController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
     })
-    public ApiResponse<CollabPostResponseDTO.CollabPostPreviewListDTO> getCollaboPostList(@RequestParam(name = "page") Integer page,
-                                                                                          @RequestParam(defaultValue = "endDate") String sortBy) {
+    public ApiResponse<CollabPostResponseDTO.PagingResultDTO> getCollaboPostList(@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime lastCreatedAt,
+                                                                                 @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") Date lastEndDate,
+                                                                                 @RequestParam(defaultValue = "10") int size,
+                                                                                 @RequestParam(defaultValue = "endDate") String sortBy) {
 
-        Page<CollabPost> collabPostPage = collabPostQueryService.getCollabPostList(page-1, sortBy);
 
-        return ApiResponse.onSuccess(CollabPostConverter.collabPostPreviewListDTO(collabPostPage));
+        CollabPostResponseDTO.PagingResultDTO<CollabPostResponseDTO.CollabPostPreviewDTO> collabPostPage = collabPostQueryService.getCollabPostList(lastCreatedAt, lastEndDate,sortBy, size);
+
+        return ApiResponse.onSuccess(collabPostPage);
     }
 
     // 콜라보 글 상세 조회
@@ -120,7 +126,7 @@ public class CollabPostRestController {
     }
 
     // 카테고리 별 콜라보 글 조회
-    @GetMapping("/categories")
+/*    @GetMapping("/categories")
     @Operation(summary = "콜라보 글 카테고리 별 조회 API (마감순, 최신순) ",
             description = "콜라보 글 카테고리 별 조회 API입니다. page는 1부터 시작합니다." +
                     "sortBy 는 정렬기준으로 기본값은 endDate(마감순) 입니다. createdAt 을 입력하면 콜라보 글 등록 최신순으로 정렬할 수 있습니다.")
@@ -134,7 +140,7 @@ public class CollabPostRestController {
         Page<CollabPost> collabPostPage = collabPostQueryService.getCollabPostListByCategory(categories, page-1, sortBy);
 
         return ApiResponse.onSuccess(CollabPostConverter.collabPostPreviewListDTO(collabPostPage));
-    }
+    }*/
 
     // 마이페이지 - 내가 쓴 콜라보레이션 모아보기
     @GetMapping("/mypage")

--- a/src/main/java/com/partnerd/web/controller/collabPostController/CollabPostRestController.java
+++ b/src/main/java/com/partnerd/web/controller/collabPostController/CollabPostRestController.java
@@ -8,16 +8,13 @@ import com.partnerd.converter.collabPostConverter.CollabPostConverter;
 import com.partnerd.domain.CollabPost;
 import com.partnerd.service.collabPostService.CollabPostCommandService;
 import com.partnerd.service.collabPostService.CollabPostQueryService;
-import com.partnerd.service.s3Service.S3Service;
 import com.partnerd.web.dto.collabDTO.request.CollabPostRequestDTO;
 import com.partnerd.web.dto.collabDTO.response.CollabPostResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.repository.query.Param;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -94,22 +91,30 @@ public class CollabPostRestController {
 
     // 콜라보 글 전체 조회 (최신순)
     @GetMapping
-    @Operation(summary = "콜라보 글 전체 조회 API (마감순, 최신순) ",
-            description = "콜라보 글 전체 조회 API입니다. page는 1부터 시작합니다." +
-                    "sortBy 는 정렬기준으로 기본값은 endDate(마감순) 입니다. createdAt 을 입력하면 콜라보 글 등록 최신순으로 정렬할 수 있습니다.")
+    @Operation(summary = "콜라보 글 전체 조회 API (마감순, 최신순)",
+            description = "콜라보 글 전체 조회 API입니다. pageNum은 1부터 시작합니다." +
+                    "sortBy는 기본값이 endDate(마감순)입니다. createdAt을 입력하면 최신순 정렬이 가능합니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
-    public ApiResponse<CollabPostResponseDTO.PagingResultDTO> getCollaboPostList(@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime lastCreatedAt,
-                                                                                 @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") Date lastEndDate,
-                                                                                 @RequestParam(defaultValue = "10") int size,
-                                                                                 @RequestParam(defaultValue = "endDate") String sortBy) {
+    public ApiResponse<CollabPostResponseDTO.PagingResultDTO> getCollaboPostList(
+            @RequestParam(defaultValue = "endDate") String sortBy,
+            @RequestParam(defaultValue = "9") int size,
+            @RequestParam(defaultValue = "1") int pageNum,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime lastCreatedAt,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") Date lastEndDate,
+            @RequestParam(required = false) Long lastId
+    ) {
+        // DTO로 변환
+        CollabPostRequestDTO.RequestNoOffsetPagingDTO requestNoOffsetPagingDTO =
+                new CollabPostRequestDTO.RequestNoOffsetPagingDTO(sortBy, size, pageNum, lastCreatedAt, lastEndDate, lastId);
 
-
-        CollabPostResponseDTO.PagingResultDTO<CollabPostResponseDTO.CollabPostPreviewDTO> collabPostPage = collabPostQueryService.getCollabPostList(lastCreatedAt, lastEndDate,sortBy, size);
+        CollabPostResponseDTO.PagingResultDTO<CollabPostResponseDTO.CollabPostPreviewDTO> collabPostPage =
+                collabPostQueryService.getCollabPostList(requestNoOffsetPagingDTO);
 
         return ApiResponse.onSuccess(collabPostPage);
     }
+
 
     // 콜라보 글 상세 조회
     @GetMapping("/{collabPostId}")

--- a/src/main/java/com/partnerd/web/dto/categoryDTO/CollabPostCategoryDTO.java
+++ b/src/main/java/com/partnerd/web/dto/categoryDTO/CollabPostCategoryDTO.java
@@ -1,0 +1,15 @@
+package com.partnerd.web.dto.categoryDTO;
+
+import lombok.*;
+
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CollabPostCategoryDTO {
+    private Long collabPostId;
+    private Long id;
+    private String name;
+}

--- a/src/main/java/com/partnerd/web/dto/collabDTO/request/CollabPostRequestDTO.java
+++ b/src/main/java/com/partnerd/web/dto/collabDTO/request/CollabPostRequestDTO.java
@@ -1,10 +1,13 @@
 package com.partnerd.web.dto.collabDTO.request;
 
 import com.partnerd.web.dto.contactMethodDTO.ContactMethodDTO;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
 
@@ -31,6 +34,51 @@ public class CollabPostRequestDTO {
         private List<Long> categoryIds;
     }
 
+
+
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RequestNoOffsetPagingDTO {
+
+        @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.")
+        private int pageNum;
+
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        private LocalDateTime lastCreatedAt; // 최신순으로 불러올 시 -> 이전 페이지의 마지막 글의 생성일
+
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        private Date lastEndDate; // 마감순으로 불러올 시 -> 이전 페이지의 마지막 글의 마감일
+
+        @Min(value = 1, message = "ID는 1 이상이어야 합니다.")
+        private Long lastId;
+
+        @NotBlank(message = "정렬 기준(sortBy)은 필수입니다.")
+        private String sortBy = "endDate";
+
+        @Min(value = 1, message = "페이지 크기는 최소 1 이상이어야 합니다.")
+        @Max(value = 100, message = "페이지 크기는 최대 100까지 가능합니다.")
+        private int size;
+
+        public RequestNoOffsetPagingDTO(String sortBy, Integer size, Integer pageNum, LocalDateTime lastCreatedAt, Date lastEndDate, Long lastId) {
+            this.sortBy = (sortBy == null || sortBy.isBlank()) ? "endDate" : sortBy;
+            this.size = (size == null || size < 1) ? 9 : size;
+            this.pageNum = (pageNum == null || pageNum < 1) ? 1 : pageNum;
+
+            // 첫 페이지면 lastCreatedAt, lastEndDate, lastId를 null로 설정
+            if (this.pageNum == 1) {
+                this.lastCreatedAt = null;
+                this.lastEndDate = null;
+                this.lastId = null;
+            } else {
+                this.lastCreatedAt = lastCreatedAt;
+                this.lastEndDate = lastEndDate;
+                this.lastId = lastId;
+            }
+        }
+    }
 
 
 }

--- a/src/main/java/com/partnerd/web/dto/collabDTO/response/CollabPostResponseDTO.java
+++ b/src/main/java/com/partnerd/web/dto/collabDTO/response/CollabPostResponseDTO.java
@@ -3,6 +3,7 @@ package com.partnerd.web.dto.collabDTO.response;
 import com.partnerd.domain.CollabInquiry;
 import com.partnerd.domain.ContactMethod;
 import com.partnerd.web.dto.categoryDTO.CategoryDTO;
+import com.partnerd.web.dto.categoryDTO.CollabPostCategoryDTO;
 import com.partnerd.web.dto.contactMethodDTO.ContactMethodDTO;
 import lombok.*;
 
@@ -21,6 +22,19 @@ public class CollabPostResponseDTO {
         private LocalDateTime createdAt;
     }
 
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PagingResultDTO<T> {
+        private List<T> data;       //  현재 페이지 데이터 리스트
+        private int listSize;       //  현재 페이지 데이터 개수
+        private long totalElements; //  전체 데이터 개수
+        private int totalPages;     //  전체 페이지 개수
+        private boolean isFirst;    //  첫 페이지 여부
+        private boolean isLast;     //  마지막 페이지 여부
+    }
     @Builder
     @Getter
     @NoArgsConstructor
@@ -31,8 +45,18 @@ public class CollabPostResponseDTO {
         private String title;
         private Date startDate;
         private Date endDate;
-        private List<CategoryDTO> categoryDTOList;
+        @Setter
+        private List<CollabPostCategoryDTO> categoryDTOList;
         private String mainImgKeyname;
+        private LocalDateTime createdAt;
+        @Builder
+        public CollabPostPreviewDTO(Long id, String title, Date startDate, Date endDate, String mainImgKeyname) {
+            this.collabPostId = id;
+            this.title = title;
+            this.startDate = startDate;
+            this.endDate = endDate;
+            this.mainImgKeyname = mainImgKeyname;
+        }
 
     }
 
@@ -41,7 +65,7 @@ public class CollabPostResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class CollabPostPreviewListDTO {
-        List<CollabPostPreviewDTO> collabPostPreviewDTOLList;
+        List<CollabPostPreviewDTO> collabPostPreviewDTOList;
         Integer listSize;
         Integer totalPage;
         Long totalElements;

--- a/src/main/java/com/partnerd/web/dto/collabDTO/response/CollabPostResponseDTO.java
+++ b/src/main/java/com/partnerd/web/dto/collabDTO/response/CollabPostResponseDTO.java
@@ -2,6 +2,7 @@ package com.partnerd.web.dto.collabDTO.response;
 
 import com.partnerd.domain.CollabInquiry;
 import com.partnerd.domain.ContactMethod;
+import com.partnerd.repository.collabPostRepository.collabPost.CollabPostRepositoryCustomImpl;
 import com.partnerd.web.dto.categoryDTO.CategoryDTO;
 import com.partnerd.web.dto.categoryDTO.CollabPostCategoryDTO;
 import com.partnerd.web.dto.contactMethodDTO.ContactMethodDTO;
@@ -30,11 +31,13 @@ public class CollabPostResponseDTO {
     public static class PagingResultDTO<T> {
         private List<T> data;       //  현재 페이지 데이터 리스트
         private int listSize;       //  현재 페이지 데이터 개수
-        private long totalElements; //  전체 데이터 개수
-        private int totalPages;     //  전체 페이지 개수
+        boolean hasMorePages;
+        int availablePages;
+        List<CollabPostRepositoryCustomImpl.PageReferenceDTO> pageReferenceDTOList;
         private boolean isFirst;    //  첫 페이지 여부
         private boolean isLast;     //  마지막 페이지 여부
     }
+
     @Builder
     @Getter
     @NoArgsConstructor

--- a/src/test/java/com/partnerd/CollabPostBatchInsertTest.java
+++ b/src/test/java/com/partnerd/CollabPostBatchInsertTest.java
@@ -1,0 +1,95 @@
+package com.partnerd;
+
+import com.partnerd.domain.CollabPost;
+import com.partnerd.domain.EventType;
+import com.partnerd.domain.mapping.ClubMember;
+import com.partnerd.repository.clubMemberRepository.ClubMemberRepository;
+import com.partnerd.repository.collabPostRepository.collabPost.EventTypeRepository;
+import com.partnerd.repository.collabPostRepository.collabPost.bulk.CollabPostBatchRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@Transactional
+@Rollback(false) // 실제 데이터 삽입 확인을 위해 롤백 방지
+public class CollabPostBatchInsertTest {
+
+    @Autowired
+    private CollabPostBatchRepository collabPostBatchRepository;
+    @Autowired
+    private EventTypeRepository eventTypeRepository;
+    @Autowired
+    private JdbcTemplate jdbcTemplate; // ✅ Batch Insert 후 데이터 개수 확인
+    @Autowired
+    private ClubMemberRepository clubMemberRepository; // ✅ 기존 ClubMember 조회
+
+    @Test
+    public void testBatchInsert() {
+        // ✅ 기존 ClubMember ID 리스트 가져오기
+        List<Long> clubMemberIds = clubMemberRepository.findAll()
+                .stream()
+                .map(ClubMember::getId)
+                .collect(Collectors.toList());
+        List<Long> eventTypeIds = eventTypeRepository.findAll()
+                .stream()
+                .map(EventType::getId)
+                .collect(Collectors.toList());
+
+        if (eventTypeIds.isEmpty()) {
+            throw new RuntimeException("event_type 테이블에 데이터가 없습니다! 먼저 데이터를 추가하세요.");
+        }
+
+        if (clubMemberIds.isEmpty()) {
+            throw new RuntimeException("ClubMember 데이터가 없습니다. 먼저 데이터를 추가하세요.");
+        }
+
+        Random random = new Random();
+
+        // 10,000개 데이터 생성
+        List<CollabPost> collabPosts = new ArrayList<>();
+        for (int i = 0; i < 100000; i++) {
+            Long randomClubMemberId = clubMemberIds.get(random.nextInt(clubMemberIds.size()));
+            Long randomEventTypeId  = eventTypeIds.get(random.nextInt(eventTypeIds.size()));
+            collabPosts.add(CollabPost.builder()
+                            .clubMember(ClubMember.builder()
+                                    .id(randomClubMemberId)
+                                    .build())
+                    .title("Batch Insert Post " + i)
+                    .intro("Batch Insert Intro")
+                    .openDate(new Date(System.currentTimeMillis()))
+                    .closeDate(new java.sql.Date(System.currentTimeMillis() + (10L * 24 * 60 * 60 * 1000))) // ✅ 10일 후 날짜
+                    .startDate(new java.sql.Date(System.currentTimeMillis() + (20L * 24 * 60 * 60 * 1000))) // ✅ 20일 후 날짜
+                    .endDate(new java.sql.Date(System.currentTimeMillis() + (30L * 24 * 60 * 60 * 1000))) // ✅ 30일 후 날짜
+                    .collabTarget("Developers")
+                    .eventMode(1)
+                    .description("Batch Insert Description")
+                    .eventType(EventType.builder()
+                            .id(randomEventTypeId).build())
+                    .build());
+
+        }
+
+        // ✅ Batch Insert 실행
+        collabPostBatchRepository.insertAll(collabPosts);
+
+        // ✅ 데이터 확인
+        long count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM collab_post", Long.class);
+        System.out.println("Total records in DB: " + count);
+
+        // ✅ 10,000개 이상 삽입 검증
+        assertTrue(count >= 10000);
+    }
+}


### PR DESCRIPTION
# PR 템플릿

## #️⃣ 연관된 이슈

> #292 



## 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?



## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

기존 페이지네이션 방식은 offset 방식으로, offset 값이 커질수록 full-scan 하는 값이 커짐에 따라 서버에 부하가 많이 감.
offset 방식에서 no-offset방식으로 변경. 추가로 UI 에 따른 페이지네이션 적용을 고려하여, 첫페이지 포함 10페이지 단위로 10페이지에 대한 데이터값들을 먼저 조회한 후 각 페이지에 해당하는 lastId와 정렬별 lastDate 값들 반환 (pageReferenceDTOList : 페이지 단위로 반환)

-> 프론트는 페이지 선택시. pageReferenceDTOList에서 선택한 페이지 값(N)의 get(N-2)의 값에 해당하는 lastDate 값과 lastId 값으로 선택 페이지의 데이터들을 조회할 수 있음.

## 💬피드백을 받고 싶은 부분 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?




### PR 특이 사항

> 어떤 부분에 리뷰어가 집중하면 좋을까요?
